### PR TITLE
Making first line non-lazy to avoid computing in workers

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -86,7 +86,7 @@ case class CsvRelation protected[spark] (
   /**
    * Returns the first line of the first non-empty file in path
    */
-  private lazy val firstLine = {
+  private val firstLine = {
     val path = new Path(location)
     val fs = FileSystem.get(path.toUri, sqlContext.sparkContext.hadoopConfiguration)
 


### PR DESCRIPTION
SparkContext object is null inside workers. Therefore the first line has to be computed on driver.
