### PR TITLE
wrong groupId

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This library requires Spark 1.2+
 You can link against this library in your program at the following coordiates:
 
 ```
-groupId: com.databricks.spark
+groupId: com.databricks
 artifactId: spark-csv_2.10
 version: 0.1
 ```


### PR DESCRIPTION
Your groupId is in fact `com.databricks`, not `com.databricks.spark` see: http://mvnrepository.com/artifact/com.databricks/spark-csv_2.10/0.1
Took me a while to figure out, with the proposed groupId it works.