### PR TITLE
CSV parser wasn't recognizing custom quote and delimiters

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -52,6 +52,7 @@ case class CsvRelation protected[spark] (
 
     val csvFormat = CSVFormat.DEFAULT
       .withDelimiter(delimiter)
+      .withQuote(quote)
       .withSkipHeaderRecord(false)
       .withHeader(fieldNames: _*)
 
@@ -69,7 +70,11 @@ case class CsvRelation protected[spark] (
   }
 
   private def inferSchema(): StructType = {
-    val firstRow = CSVParser.parse(firstLine, CSVFormat.DEFAULT).getRecords.head.toList
+    val csvFormat = CSVFormat.DEFAULT
+      .withDelimiter(delimiter)
+      .withQuote(quote)
+      .withSkipHeaderRecord(false)
+    val firstRow = CSVParser.parse(firstLine, csvFormat).getRecords.head.toList
     if (this.userSchema != null) {
       userSchema
     } else {

--- a/src/test/resources/cars-alternative.csv
+++ b/src/test/resources/cars-alternative.csv
@@ -1,0 +1,4 @@
+year|make|model|comment
+'2012'|'Tesla'|'S'| 'No comment'
+
+1997|Ford|E350|'Go get one now they are going fast'

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -23,6 +23,7 @@ import TestSQLContext._
 
 class CsvSuite extends FunSuite {
   val carsFile = "src/test/resources/cars.csv"
+  val carsAltFile = "src/test/resources/cars-alternative.csv"
 
   test("dsl test") {
     val results = TestSQLContext
@@ -43,4 +44,16 @@ class CsvSuite extends FunSuite {
 
     assert(sql("SELECT year FROM carsTable").collect().size === 2)
   }
+
+  test("dsl test with alternative delimiter and quote") {
+    val results = new CsvParser()
+      .withDelimiter('|')
+      .withQuoteChar('\'')
+      .csvFile(TestSQLContext, carsAltFile)
+      .select('year)
+      .collect()
+
+    assert(results.size === 2)
+  }
+
 }


### PR DESCRIPTION
Ran into troubles parsing content with an unusual delimiter, and noticed that the delimiter wasn't being set when parsing the first line. This fixed my problem.

I'm not a scala guy, so the fix could easily be in the wrong style.