### PR TITLE
Allowing for empty files when the schema is defined

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -70,14 +70,14 @@ case class CsvRelation protected[spark] (
   }
 
   private def inferSchema(): StructType = {
-    val csvFormat = CSVFormat.DEFAULT
-      .withDelimiter(delimiter)
-      .withQuote(quote)
-      .withSkipHeaderRecord(false)
-    val firstRow = CSVParser.parse(firstLine, csvFormat).getRecords.head.toList
     if (this.userSchema != null) {
       userSchema
     } else {
+      val csvFormat = CSVFormat.DEFAULT
+        .withDelimiter(delimiter)
+        .withQuote(quote)
+        .withSkipHeaderRecord(false)
+      val firstRow = CSVParser.parse(firstLine, csvFormat).getRecords.head.toList
       val header = if (useHeader) {
         firstRow
       } else {

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -16,6 +16,7 @@
 package com.databricks.spark.csv
 
 import org.apache.spark.sql.test._
+import org.apache.spark.sql.catalyst.types._
 import org.scalatest.FunSuite
 
 /* Implicits */
@@ -24,6 +25,7 @@ import TestSQLContext._
 class CsvSuite extends FunSuite {
   val carsFile = "src/test/resources/cars.csv"
   val carsAltFile = "src/test/resources/cars-alternative.csv"
+  val emptyFile = "src/test/resources/empty.csv"
 
   test("dsl test") {
     val results = TestSQLContext
@@ -54,6 +56,17 @@ class CsvSuite extends FunSuite {
       .collect()
 
     assert(results.size === 2)
+  }
+
+  test("dsl test with empty file and known schema") {
+    val results = new CsvParser()
+      .withDelimiter('|')
+      .withQuoteChar('\'')
+      .withSchema(StructType(List(StructField("column", StringType, false))))
+      .csvFile(TestSQLContext, emptyFile)
+      .count()
+
+    assert(results === 0)
   }
 
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -60,8 +60,6 @@ class CsvSuite extends FunSuite {
 
   test("dsl test with empty file and known schema") {
     val results = new CsvParser()
-      .withDelimiter('|')
-      .withQuoteChar('\'')
       .withSchema(StructType(List(StructField("column", StringType, false))))
       .csvFile(TestSQLContext, emptyFile)
       .count()


### PR DESCRIPTION
We're aggregating multiple files with a known schema. Sometimes those files are empty. The `inferSchema` call was trying to read the first line, which seemed unnecessary when the schema was already defined. Added test case for an empty csv.