### PR TITLE
Use C for column names

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -81,7 +81,7 @@ case class CsvRelation protected[spark] (
       val header = if (useHeader) {
         firstRow
       } else {
-        firstRow.zipWithIndex.map { case (value, index) => s"V$index"}
+        firstRow.zipWithIndex.map { case (value, index) => s"C$index"}
       }
       // By default fields are assumed to be StringType
       val schemaFields = header.map { fieldName =>

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -79,5 +79,13 @@ class CsvSuite extends FunSuite {
     assert(results === 0)
   }
 
+  test("column names test") {
+    val cars = new CsvParser()
+      .withUseHeader(false)
+      .csvFile(TestSQLContext, carsFile)
+    assert(cars.schema.fields(0).name == "C0")
+    assert(cars.schema.fields(2).name == "C2")
+  }
+
   //TODO(hossein): When relation Schema PR gets merged add a sql test for empty file
 }


### PR DESCRIPTION
When visualizing the results C$i might be a better abbreviation.