### PR TITLE
Add support for quoting on save.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.3.0" % "provided"
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
-libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.3.2"
-
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.9" % "test"

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.3.0" % "provided"
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
+libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.3.2"
+
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.9" % "test"

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -57,6 +57,11 @@ class CsvParser {
     this
   }
 
+  def withEscape(escapeChar: Character): CsvParser = {
+    this.escape = escapeChar
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -28,6 +28,7 @@ class CsvParser {
   private var useHeader: Boolean = false
   private var delimiter: Character = ','
   private var quote: Character = '"'
+  private var escape: Character = '\\'
   private var schema: StructType = null
   private var parseMode: String = ParseModes.DEFAULT
 
@@ -64,6 +65,7 @@ class CsvParser {
       useHeader,
       delimiter,
       quote,
+      escape,
       parseMode,
       schema)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -63,6 +63,7 @@ case class CsvRelation protected[spark] (
     val csvFormat = CSVFormat.DEFAULT
       .withDelimiter(delimiter)
       .withQuote(quote)
+      .withEscape('\\')
       .withSkipHeaderRecord(false)
       .withHeader(fieldNames: _*)
 
@@ -88,6 +89,7 @@ case class CsvRelation protected[spark] (
       val csvFormat = CSVFormat.DEFAULT
         .withDelimiter(delimiter)
         .withQuote(quote)
+        .withEscape('\\')
         .withSkipHeaderRecord(false)
       val firstRow = CSVParser.parse(firstLine, csvFormat).getRecords.head.toList
       val header = if (useHeader) {

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -35,6 +35,7 @@ case class CsvRelation protected[spark] (
     useHeader: Boolean,
     delimiter: Char,
     quote: Char,
+    escape: Char,
     parseMode: String,
     userSchema: StructType = null)(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with InsertableRelation {
@@ -63,7 +64,7 @@ case class CsvRelation protected[spark] (
     val csvFormat = CSVFormat.DEFAULT
       .withDelimiter(delimiter)
       .withQuote(quote)
-      .withEscape('\\')
+      .withEscape(escape)
       .withSkipHeaderRecord(false)
       .withHeader(fieldNames: _*)
 
@@ -89,7 +90,7 @@ case class CsvRelation protected[spark] (
       val csvFormat = CSVFormat.DEFAULT
         .withDelimiter(delimiter)
         .withQuote(quote)
-        .withEscape('\\')
+        .withEscape(escape)
         .withSkipHeaderRecord(false)
       val firstRow = CSVParser.parse(firstLine, csvFormat).getRecords.head.toList
       val header = if (useHeader) {

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -62,6 +62,13 @@ class DefaultSource
       throw new Exception("Quotation cannot be more than one character.")
     }
 
+    val escape = parameters.getOrElse("escape", "\\")
+    val escapeChar = if (escape.length == 1) {
+      escape.charAt(0)
+    } else {
+      throw new Exception("Escape character cannot be more than one character.")
+    }
+
     val parseMode = parameters.getOrElse("mode", "PERMISSIVE")
 
     val useHeader = parameters.getOrElse("header", "false")
@@ -73,7 +80,13 @@ class DefaultSource
       throw new Exception("Header flag can be true or false")
     }
 
-    CsvRelation(path, headerFlag, delimiterChar, quoteChar, parseMode, schema)(sqlContext)
+    CsvRelation(path,
+      headerFlag,
+      delimiterChar,
+      quoteChar,
+      escapeChar,
+      parseMode,
+      schema)(sqlContext)
   }
 
   override def createRelation(

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -16,9 +16,9 @@
 package com.databricks.spark
 
 import org.apache.commons.csv.CSVFormat
-import org.apache.spark.sql.{SQLContext, DataFrame, Row}
 import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.commons.lang3.StringUtils
+
+import org.apache.spark.sql.{SQLContext, DataFrame, Row}
 
 package object csv {
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -76,7 +76,17 @@ package object csv {
         throw new Exception("Escape character cannot be more than one character.")
       }
 
-      val quote = parameters.get("quote")
+      val quoteChar = parameters.get("quote") match {
+        case Some(s) => {
+          if (s.length == 1) {
+            Some(s.charAt(0))
+          } else {
+            throw new Exception("Quotation cannot be more than one character.")
+          }
+        }
+        case None => None
+      }
+
       val generateHeader = parameters.getOrElse("header", "false").toBoolean
       val header = if (generateHeader) {
         dataFrame.columns.map(c => s""""$c"""").mkString(delimiter)
@@ -90,14 +100,8 @@ package object csv {
           .withSkipHeaderRecord(false)
           .withNullString("null")
 
-        val csvFormat = quote match {
-          case Some(s) => {
-            if (s.length == 1) {
-              csvFormatBase.withQuote(s.charAt(0))
-            } else {
-              throw new Exception("Quotation cannot be more than one character.")
-            }
-          }
+        val csvFormat = quoteChar match {
+          case Some(c) => csvFormatBase.withQuote(c)
           case _ => csvFormatBase
         }
 

--- a/src/test/resources/escape.csv
+++ b/src/test/resources/escape.csv
@@ -1,0 +1,2 @@
+"column"
+|"thing

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -30,6 +30,7 @@ class CsvSuite extends FunSuite {
   val carsFile = "src/test/resources/cars.csv"
   val carsAltFile = "src/test/resources/cars-alternative.csv"
   val emptyFile = "src/test/resources/empty.csv"
+  val escapeFile = "src/test/resources/escape.csv"
   val tempEmptyDir = "target/test/empty/"
 
   val numCars = 3
@@ -258,5 +259,21 @@ class CsvSuite extends FunSuite {
 
     assert(carsCopy.count == cars.count)
     assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
-  } 
+  }
+  
+  test("DSL save with quoting, escaped quote") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "escape-copy.csv"
+
+    val escape = TestSQLContext.csvFile(escapeFile, escape='|', quote='"')
+    escape.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "\""))
+
+    val escapeCopy = TestSQLContext.csvFile(copyFilePath + "/")
+
+    assert(escapeCopy.count == escape.count)
+    assert(escapeCopy.collect.map(_.toString).toSet == escape.collect.map(_.toString).toSet)
+    assert(escapeCopy.head().getString(0) == "\"thing")
+  }
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -229,4 +229,34 @@ class CsvSuite extends FunSuite {
     assert(carsCopy.count == cars.count)
     assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
   }
+
+  test("DSL save with quoting") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "cars-copy.csv"
+
+    val cars = TestSQLContext.csvFile(carsFile)
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "\""))
+
+    val carsCopy = TestSQLContext.csvFile(copyFilePath + "/")
+
+    assert(carsCopy.count == cars.count)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
+  }
+
+  test("DSL save with alternate quoting") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "cars-copy.csv"
+
+    val cars = TestSQLContext.csvFile(carsFile)
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "!"))
+
+    val carsCopy = TestSQLContext.csvFile(copyFilePath + "/", quote = '!')
+
+    assert(carsCopy.count == cars.count)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
+  } 
 }


### PR DESCRIPTION
Adds support for saving with quoting around each elements and any existing occurrences of the quote being escaped. Because ```CSVFormat``` can handle unquoting, the roundtrip is lossless.

A few notes/questions:
* Performance on this is not that great. I clocked some example data taking about 1.5x as long to save quoted vs. unquoted. There should be little cost to non-quoted saves with this patch (just an additional function call or two of indirection). Any ideas for performance improvements would be great!
* I brought in ```commons-lang```. Spark already requires this, so hopefully it's not too big of a deal. I can't decide if it's better to have an explicit version dep or go with provided as such.
* I attempted to use ```commons-csv```, but was hampered by the insistence on [writing the delimiter at the top of every output](https://github.com/apache/commons-csv/blob/trunk/src/main/java/org/apache/commons/csv/CSVPrinter.java#L127). It might not be too hard to undo this, but like a more kludge-y approach.