### PR TITLE
more efficient, robust and flexible csv parsing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ organization := "com.databricks"
 
 scalaVersion := "2.11.6"
 
+parallelExecution in Test := false
+
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.3.0" % "provided"

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.3.0" % "provided"
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
-libraryDependencies += "com.univocity" % "univocity-parsers" % "1.3.1"
+libraryDependencies += "com.univocity" % "univocity-parsers" % "1.5.1"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
 

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,8 @@ libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.3.0" % "provided"
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
+libraryDependencies += "com.univocity" % "univocity-parsers" % "1.3.1"
+
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
 
 resolvers ++= Seq(

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -15,10 +15,10 @@
  */
 package com.databricks.spark.csv
 
-import org.apache.spark.sql.{SQLContext, DataFrame}
-import org.apache.spark.sql.types.StructType
 
-import com.databricks.spark.csv.util.ParseModes
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.types.StructType
+import com.databricks.spark.csv.util.{ParserLibs, ParseModes}
 
 /**
  * A collection of static functions for working with CSV files in Spark SQL
@@ -31,6 +31,10 @@ class CsvParser {
   private var escape: Character = '\\'
   private var schema: StructType = null
   private var parseMode: String = ParseModes.DEFAULT
+  private var ignoreLeadingWhiteSpace: Boolean = false
+  private var ignoreTrailingWhiteSpace: Boolean = false
+  private var parserLib: String = ParserLibs.DEFAULT
+
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -62,6 +66,21 @@ class CsvParser {
     this
   }
 
+  def withIgnoreLeadingWhiteSpace(ignore: Boolean): CsvParser = {
+    this.ignoreLeadingWhiteSpace = ignore
+    this
+  }
+
+  def withIgnoreTrailingWhiteSpace(ignore: Boolean): CsvParser = {
+    this.ignoreTrailingWhiteSpace = ignore
+    this
+  }
+
+  def withParserLib(parserLib: String): CsvParser = {
+    this.parserLib = parserLib
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -72,6 +91,9 @@ class CsvParser {
       quote,
       escape,
       parseMode,
+      parserLib,
+      ignoreLeadingWhiteSpace,
+      ignoreTrailingWhiteSpace,
       schema)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }

--- a/src/main/scala/com/databricks/spark/csv/CsvReader.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvReader.scala
@@ -20,14 +20,14 @@ import java.io.StringReader
 import com.univocity.parsers.csv._
 
 abstract class CsvReader(fieldSep: Char = ',',
-                         lineSep: String = "\n",
-                         quote: Char = '"',
-                         escape: Char = '\\',
-                         ignoreLeadingSpace: Boolean = true,
-                         ignoreTrailingSpace: Boolean = true,
-                         headers: Seq[String],
-                         inputBufSize: Int = 128,
-                         maxCols: Int = 20480) {
+    lineSep: String = "\n",
+    quote: Char = '"',
+    escape: Char = '\\',
+    ignoreLeadingSpace: Boolean = true,
+    ignoreTrailingSpace: Boolean = true,
+    headers: Seq[String],
+    inputBufSize: Int = 128,
+    maxCols: Int = 20480) {
   lazy val parser = {
     val settings = new CsvParserSettings()
     val format = settings.getFormat
@@ -51,13 +51,13 @@ abstract class CsvReader(fieldSep: Char = ',',
  * Parser for parsing a line at a time. Not efficient for bulk data.
  */
 class LineCsvReader(fieldSep: Char = ',',
-                    lineSep: String = "\n",
-                    quote: Char = '"',
-                    escape: Char = '\\',
-                    ignoreLeadingSpace: Boolean = true,
-                    ignoreTrailingSpace: Boolean = true,
-                    inputBufSize: Int = 128,
-                    maxCols: Int = 20480)
+    lineSep: String = "\n",
+    quote: Char = '"',
+    escape: Char = '\\',
+    ignoreLeadingSpace: Boolean = true,
+    ignoreTrailingSpace: Boolean = true,
+    inputBufSize: Int = 128,
+    maxCols: Int = 20480)
   extends CsvReader(fieldSep,
     lineSep,
     quote,
@@ -85,16 +85,16 @@ class LineCsvReader(fieldSep: Char = ',',
  * @param iter iterator over lines in the file
  */
 class BulkCsvReader (iter: Iterator[String],
-                     split: Int,      // for debugging
-                     fieldSep: Char = ',',
-                     lineSep: String = "\n",
-                     quote: Char = '"',
-                     escape: Char = '\\',
-                     ignoreLeadingSpace: Boolean = true,
-                     ignoreTrailingSpace: Boolean = true,
-                     headers: Seq[String],
-                     inputBufSize: Int = 128,
-                     maxCols: Int = 20480)
+    split: Int,      // for debugging
+    fieldSep: Char = ',',
+    lineSep: String = "\n",
+    quote: Char = '"',
+    escape: Char = '\\',
+    ignoreLeadingSpace: Boolean = true,
+    ignoreTrailingSpace: Boolean = true,
+    headers: Seq[String],
+    inputBufSize: Int = 128,
+    maxCols: Int = 20480)
   extends CsvReader(fieldSep,
     lineSep,
     quote,

--- a/src/main/scala/com/databricks/spark/csv/CsvReader.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvReader.scala
@@ -40,6 +40,7 @@ abstract class CsvReader(fieldSep: Char = ',',
     settings.setReadInputOnSeparateThread(false)
     settings.setInputBufferSize(inputBufSize)
     settings.setMaxColumns(maxCols)
+    settings.setNullValue("")
     if(headers != null) settings.setHeaders(headers:_*)
 
     new CsvParser(settings)

--- a/src/main/scala/com/databricks/spark/csv/CsvReader.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvReader.scala
@@ -1,3 +1,4 @@
+// scalastyle:off
 /*
  * Copyright 2015 Ayasdi Inc
  *
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// scalastyle:on
 
 package com.databricks.spark.sql.readers
 

--- a/src/main/scala/com/databricks/spark/csv/CsvReader.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvReader.scala
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2015 Ayasdi Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.ayasdi.bigdf.readers
+
+import java.io.StringReader
+import com.univocity.parsers.csv._
+
+abstract class CsvReader(fieldSep: Char = ',',
+                         lineSep: String = "\n",
+                         quote: Char = '"',
+                         escape: Char = '\\',
+                         ignoreLeadingSpace: Boolean = true,
+                         ignoreTrailingSpace: Boolean = true,
+                         headers: Seq[String],
+                         inputBufSize: Int = 128,
+                         maxCols: Int = 20480) {
+  lazy val parser = {
+    val settings = new CsvParserSettings()
+    val format = settings.getFormat
+    format.setDelimiter(fieldSep)
+    format.setLineSeparator(lineSep)
+    format.setQuote(quote)
+    format.setQuoteEscape(escape)
+    settings.setIgnoreLeadingWhitespaces(ignoreLeadingSpace)
+    settings.setIgnoreTrailingWhitespaces(ignoreTrailingSpace)
+    settings.setReadInputOnSeparateThread(false)
+    settings.setInputBufferSize(inputBufSize)
+    settings.setMaxColumns(maxCols)
+    if(headers != null) settings.setHeaders(headers:_*)
+
+    new CsvParser(settings)
+  }
+}
+
+/**
+ * Parser for parsing a line at a time. Not efficient for bulk data.
+ */
+class LineCsvReader(fieldSep: Char = ',',
+                    lineSep: String = "\n",
+                    quote: Char = '"',
+                    escape: Char = '\\',
+                    ignoreLeadingSpace: Boolean = true,
+                    ignoreTrailingSpace: Boolean = true,
+                    inputBufSize: Int = 128,
+                    maxCols: Int = 20480)
+  extends CsvReader(fieldSep,
+    lineSep,
+    quote,
+    escape,
+    ignoreLeadingSpace,
+    ignoreTrailingSpace,
+    null,
+    inputBufSize,
+    maxCols) {
+  /**
+   * parse a line
+   * @param line a String with no newline at the end
+   * @return array of strings where each string is a field in the CSV record
+   */
+  def parseLine(line: String): Array[String] = {
+    parser.beginParsing(new StringReader(line))
+    val parsed = parser.parseNext()
+    parser.stopParsing()
+    parsed
+  }
+}
+
+/**
+ * Parser for parsing lines in bulk. Use this when efficiency is desired.
+ * @param iter iterator over lines in the file
+ */
+class BulkCsvReader (iter: Iterator[String],
+                     split: Int,      // for debugging
+                     fieldSep: Char = ',',
+                     lineSep: String = "\n",
+                     quote: Char = '"',
+                     escape: Char = '\\',
+                     ignoreLeadingSpace: Boolean = true,
+                     ignoreTrailingSpace: Boolean = true,
+                     headers: Seq[String],
+                     inputBufSize: Int = 128,
+                     maxCols: Int = 20480)
+  extends CsvReader(fieldSep,
+    lineSep,
+    quote,
+    escape,
+    ignoreLeadingSpace,
+    ignoreTrailingSpace,
+    headers,
+    inputBufSize,
+    maxCols)
+  with Iterator[Array[String]] {
+
+  val reader = new StringIteratorReader(iter, lineSep)
+  parser.beginParsing(reader)
+  var nextRecord =  parser.parseNext()
+
+  /**
+   * get the next parsed line.
+   * @return array of strings where each string is a field in the CSV record
+   */
+  def next = {
+    val curRecord = nextRecord
+    if(curRecord != null)
+      nextRecord = parser.parseNext()
+    else
+      throw new NoSuchElementException("next record is null")
+    curRecord
+  }
+
+  def hasNext = nextRecord != null
+
+}
+
+/**
+ * A Reader that "reads" from a sequence of lines. Spark's textFile method removes newlines at end of
+ * each line
+ * Univocity parser requires a Reader that provides access to the data to be parsed and needs the newlines to
+ * be present
+ * @param iter iterator over RDD[String]
+ */
+class StringIteratorReader(val iter: Iterator[String], val lineSep: String) extends java.io.Reader {
+  require(lineSep.length == 1)
+  private var next: Long = 0
+  private var length: Long = 0
+  private var start: Long = 0
+  private var str: String = null
+  private val lineSepLen = lineSep.length
+
+  private def refill(): Unit = {
+    if(length == next) {
+      if(iter.hasNext) {
+        str = iter.next
+        start = length
+        length += (str.length + lineSepLen) //allowance for line separator removed by SparkContext.textFile()
+      } else {
+        str = null
+      }
+    }
+  }
+
+  override def read(): Int = {
+    refill()
+    if(next >= length) {
+      -1
+    } else {
+      val cur = next - start
+      next += 1
+      if (cur == str.length)
+        '\n'
+      else
+        str.charAt(cur.toInt)
+    }
+  }
+
+  def read(cbuf: Array[Char], off: Int, len: Int): Int = {
+    refill()
+    var n = 0
+    if ((off < 0) || (off > cbuf.length) || (len < 0) ||
+      ((off + len) > cbuf.length) || ((off + len) < 0)) {
+      throw new IndexOutOfBoundsException()
+    } else if (len == 0) {
+      n = 0
+    }
+    else {
+      if (next >= length) {
+        n = -1
+      } else {
+        n = Math.min(length - next, len).toInt
+        if (n == length - next) {
+          str.getChars((next - start).toInt, (next - start + n - 1).toInt, cbuf, off)
+          cbuf(off + n - lineSepLen) = lineSep.charAt(0)
+        } else {
+          str.getChars((next - start).toInt, (next - start + n).toInt, cbuf, off)
+        }
+        next += n
+        if (n < len) {
+          val m = read(cbuf, off + n, len - n)
+          if(m != -1)
+            n += m
+        }
+      }
+    }
+
+    n
+  }
+
+  override def skip(ns: Long): Long = {
+    throw new IllegalArgumentException("Skip not implemented")
+  }
+
+  override def ready = {
+    refill()
+    true
+  }
+
+  override def markSupported = false
+
+  override def mark(readAheadLimit: Int): Unit = {
+    throw new IllegalArgumentException("Mark not implemented")
+  }
+
+  override def reset(): Unit = {
+    throw new IllegalArgumentException("Mark and hence reset not implemented")
+  }
+
+  def close(): Unit = { }
+}

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -29,8 +29,8 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import com.ayasdi.bigdf.readers._
 import com.databricks.spark.csv.util.ParseModes
+import com.databricks.spark.sql.readers._
 
 case class CsvRelation protected[spark] (
     location: String,

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -17,19 +17,20 @@ package com.databricks.spark.csv
 
 import java.io.IOException
 
-import com.ayasdi.bigdf.readers._
-import com.databricks.spark.csv.util.ParseModes
+import scala.collection.JavaConversions._
+import scala.util.control.NonFatal
+
 import org.apache.commons.csv._
 import org.apache.hadoop.fs.Path
+import org.slf4j.LoggerFactory
+
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.catalyst.expressions._
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.slf4j.LoggerFactory
-
-import scala.collection.JavaConversions._
-import scala.util.control.NonFatal
+import com.ayasdi.bigdf.readers._
+import com.databricks.spark.csv.util.ParseModes
 
 case class CsvRelation protected[spark] (
     location: String,

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -101,9 +101,17 @@ case class CsvRelation protected[spark] (
     if (this.userSchema != null) {
       userSchema
     } else {
-      val firstRow =
+      val firstRow = if(ParserLibs.isUnivocityLib(parserLib)) {
         new LineCsvReader(fieldSep = delimiter, quote = quote, escape = escape)
           .parseLine(firstLine)
+      } else {
+        val csvFormat = CSVFormat.DEFAULT
+          .withDelimiter(delimiter)
+          .withQuote(quote)
+          .withEscape(escape)
+          .withSkipHeaderRecord(false)
+        CSVParser.parse(firstLine, csvFormat).getRecords.head.toArray
+      }
       val header = if (useHeader) {
         firstRow
       } else {

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -19,6 +19,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
+import com.databricks.spark.csv.util.ParserLibs
 
 /**
  * Provides access to CSV data from pure SQL statements (i.e. for users of the
@@ -80,12 +81,40 @@ class DefaultSource
       throw new Exception("Header flag can be true or false")
     }
 
+    val parserLib = parameters.getOrElse("parserLib", ParserLibs.DEFAULT)
+    val ignoreLeadingWhiteSpace = parameters.getOrElse("ignoreLeadingWhiteSpace", "false")
+    val ignoreLeadingWhiteSpaceFlag = if(ignoreLeadingWhiteSpace == "false") {
+      false
+    } else if(ignoreLeadingWhiteSpace == "true") {
+      if(!ParserLibs.isUnivocityLib(parserLib)) {
+        throw new Exception("Ignore whitesspace supported for Univocity parser only")
+      }
+      true
+    } else {
+      throw new Exception("Ignore white space flag can be true or false")
+    }
+    val ignoreTrailingWhiteSpace = parameters.getOrElse("ignoreTrailingWhiteSpace", "false")
+    val ignoreTrailingWhiteSpaceFlag = if(ignoreTrailingWhiteSpace == "false") {
+      false
+    } else if(ignoreTrailingWhiteSpace == "true") {
+      if(!ParserLibs.isUnivocityLib(parserLib)) {
+        throw new Exception("Ignore whitespace supported for the Univocity parser only")
+      }
+      true
+    } else {
+      throw new Exception("Ignore white space flag can be true or false")
+    }
+
+
     CsvRelation(path,
       headerFlag,
       delimiterChar,
       quoteChar,
       escapeChar,
       parseMode,
+      parserLib,
+      ignoreLeadingWhiteSpaceFlag,
+      ignoreTrailingWhiteSpaceFlag,
       schema)(sqlContext)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -119,7 +119,7 @@ package object csv {
         }
 
         new Iterator[String] {
-          var firstRow: Boolean = generateHeader && index == 0
+          var firstRow: Boolean = generateHeader //&& index == 0
 
           override def hasNext = iter.hasNext
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -31,25 +31,38 @@ package object csv {
                 delimiter: Char = ',',
                 quote: Char = '"',
                 escape: Char = '\\',
-                mode: String = "PERMISSIVE") = {
+                mode: String = "PERMISSIVE",
+                parserLib: String = "COMMONS",
+                ignoreLeadingWhiteSpace: Boolean = false,
+                ignoreTrailingWhiteSpace: Boolean = false) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
         delimiter = delimiter,
         quote = quote,
         escape = escape,
-        parseMode = mode)(sqlContext)
+        parseMode = mode,
+        parserLib = parserLib,
+        ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
+        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
-    def tsvFile(filePath: String, useHeader: Boolean = true) = {
+    def tsvFile(filePath: String,
+                useHeader: Boolean = true,
+                parserLib: String = "COMMONS",
+                ignoreLeadingWhiteSpace: Boolean = false,
+                ignoreTrailingWhiteSpace: Boolean = false) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
         delimiter = '\t',
         quote = '"',
         escape = '\\',
-        parseMode = "PERMISSIVE")(sqlContext)
+        parseMode = "PERMISSIVE",
+        parserLib = parserLib,
+        ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
+        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -119,7 +119,7 @@ package object csv {
         }
 
         new Iterator[String] {
-          var firstRow: Boolean = generateHeader //&& index == 0
+          var firstRow: Boolean = generateHeader
 
           override def hasNext = iter.hasNext
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -17,6 +17,7 @@ package com.databricks.spark
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.hadoop.io.compress.CompressionCodec
+
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
 package object csv {
@@ -92,7 +93,7 @@ package object csv {
       } else {
         "" // There is no need to generate header in this case
       }
-      val strRDD = dataFrame.rdd.mapPartitionsWithIndex { case (index, iter) => {
+      val strRDD = dataFrame.rdd.mapPartitionsWithIndex { case (index, iter) =>
         val csvFormatBase = CSVFormat.DEFAULT
           .withDelimiter(delimiterChar)
           .withEscape(escapeChar)
@@ -119,7 +120,6 @@ package object csv {
             }
           }
         }
-      }
       }
       compressionCodec match {
         case null => strRDD.saveAsTextFile(path)

--- a/src/main/scala/com/databricks/spark/csv/util/ParserLibs.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/ParserLibs.scala
@@ -1,3 +1,4 @@
+// scalastyle:off
 /*
  * Copyright 2015 Ayasdi Inc
  *
@@ -13,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+// scalastyle:on
 package com.databricks.spark.csv.util
 
 private[csv] object ParserLibs {

--- a/src/main/scala/com/databricks/spark/csv/util/ParserLibs.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/ParserLibs.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2015 Ayasdi Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.csv.util
+
+private[csv] object ParserLibs {
+  val OLD = "COMMONS"
+  val NEW = "UNIVOCITY"
+
+  val DEFAULT = OLD
+
+  def isValidLib(lib: String): Boolean = {
+    lib.toUpperCase match {
+      case OLD | NEW  => true
+      case _ => false
+    }
+  }
+
+  def isCommonsLib(lib: String): Boolean = if (isValidLib(lib)) {
+    lib.toUpperCase == OLD
+  } else {
+    true  // default
+  }
+
+  def isUnivocityLib(lib: String): Boolean = if (isValidLib(lib)) {
+    lib.toUpperCase == NEW
+  } else {
+    false  // not the default
+  }
+
+}

--- a/src/test/resources/escape.csv
+++ b/src/test/resources/escape.csv
@@ -1,2 +1,2 @@
 "column"
-|"thing
+"|"thing"

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2015 Ayasdi Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.csv
+
+import java.io.File
+
+import org.apache.hadoop.io.compress.GzipCodec
+import org.apache.spark.sql.test._
+import org.apache.spark.SparkException
+import org.apache.spark.sql.types._
+import org.scalatest.FunSuite
+
+/* Implicits */
+import TestSQLContext._
+
+class CsvFastSuite extends FunSuite {
+  val carsFile = "src/test/resources/cars.csv"
+  val carsAltFile = "src/test/resources/cars-alternative.csv"
+  val emptyFile = "src/test/resources/empty.csv"
+  val escapeFile = "src/test/resources/escape.csv"
+  val tempEmptyDir = "target/test/empty/"
+
+  val numCars = 3
+
+  test("DSL test") {
+    val results = TestSQLContext
+      .csvFile(carsFile, parserLib = "univocity")
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars)
+  }
+
+  test("DDL test") {
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTable
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsFile", header "true", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT year FROM carsTable").collect().size === numCars)
+  }
+
+  test("DSL test for DROPMALFORMED parsing mode") {
+    val results = new CsvParser()
+      .withParseMode("DROPMALFORMED")
+      .withUseHeader(true)
+      .withParserLib("univocity")
+      .csvFile(TestSQLContext, carsFile)
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars - 1)
+  }
+
+  test("DSL test for FAILFAST parsing mode") {
+    val parser = new CsvParser()
+      .withParseMode("FAILFAST")
+      .withUseHeader(true)
+      .withParserLib("univocity")
+
+    val exception = intercept[SparkException]{
+      parser.csvFile(TestSQLContext, carsFile)
+        .select("year")
+        .collect()
+    }
+
+    assert(exception.getMessage.contains("Malformed line in FAILFAST mode"))
+  }
+
+
+  test("DSL test with alternative delimiter and quote") {
+    val results = new CsvParser()
+      .withDelimiter('|')
+      .withQuoteChar('\'')
+      .withUseHeader(true)
+      .withParserLib("univocity")
+      .csvFile(TestSQLContext, carsAltFile)
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars)
+  }
+
+  test("DSL test with alternative delimiter and quote using sparkContext.csvFile") {
+    val results =
+      TestSQLContext.csvFile(carsAltFile, useHeader = true, delimiter = '|', quote = '\'', parserLib = "univocity")
+        .select("year")
+        .collect()
+
+    assert(results.size === numCars)
+  }
+
+  test("Expect parsing error with wrong delimiter settting using sparkContext.csvFile") {
+    intercept[ org.apache.spark.sql.AnalysisException] {
+      TestSQLContext.csvFile(carsAltFile, useHeader = true, delimiter = ',', quote = '\'', parserLib = "univocity")
+        .select("year")
+        .collect()
+    }
+  }
+
+  test("Expect wrong parsing results with wrong quote setting using sparkContext.csvFile") {
+    val results =
+      TestSQLContext.csvFile(carsAltFile, useHeader = true, delimiter = '|', quote = '"', parserLib = "univocity")
+        .select("year")
+        .collect()
+
+    assert(results.slice(0, numCars).toSeq.map(_(0).asInstanceOf[String]) ==
+      Seq("'2012'", "1997", "2015"))
+  }
+
+  test("DDL test with alternative delimiter and quote") {
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTable
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsAltFile", header "true", quote "'", delimiter "|", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT year FROM carsTable").collect().size === numCars)
+  }
+
+
+  test("DSL test with empty file and known schema") {
+    val results = new CsvParser()
+      .withSchema(StructType(List(StructField("column", StringType, false))))
+      .withUseHeader(false)
+      .withParserLib("univocity")
+      .csvFile(TestSQLContext, emptyFile)
+      .count()
+
+    assert(results === 0)
+  }
+
+  test("DDL test with empty file") {
+    sql(s"""
+           |CREATE TEMPORARY TABLE carsTable
+           |(yearMade double, makeName string, modelName string, comments string, grp string)
+           |USING com.databricks.spark.csv
+           |OPTIONS (path "$emptyFile", header "false", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT count(*) FROM carsTable").collect().head(0) === 0)
+  }
+
+  test("DDL test with schema") {
+    sql(s"""
+           |CREATE TEMPORARY TABLE carsTable
+           |(yearMade double, makeName string, modelName string, comments string, grp string)
+           |USING com.databricks.spark.csv
+           |OPTIONS (path "$carsFile", header "true", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT makeName FROM carsTable").collect().size === numCars)
+    assert(sql("SELECT avg(yearMade) FROM carsTable where grp = '' group by grp")
+      .collect().head(0) === 2004.5)
+  }
+
+  test("DSL column names test") {
+    val cars = new CsvParser()
+      .withUseHeader(false)
+      .withParserLib("univocity")
+      .csvFile(TestSQLContext, carsFile)
+    assert(cars.schema.fields(0).name == "C0")
+    assert(cars.schema.fields(2).name == "C2")
+  }
+
+  test("SQL test insert overwrite") {
+    // Create a temp directory for table that will be overwritten
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTableIO
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsFile", header "false", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+    sql(s"""
+           |CREATE TEMPORARY TABLE carsTableEmpty
+           |(yearMade double, makeName string, modelName string, comments string, grp string)
+           |USING com.databricks.spark.csv
+           |OPTIONS (path "$tempEmptyDir", header "false", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT * FROM carsTableIO").collect().size === numCars + 1)
+    assert(sql("SELECT * FROM carsTableEmpty").collect().isEmpty)
+
+    sql(
+      s"""
+         |INSERT OVERWRITE TABLE carsTableEmpty
+         |SELECT * FROM carsTableIO
+      """.stripMargin.replaceAll("\n", " "))
+    assert(sql("SELECT * FROM carsTableEmpty").collect().size == numCars + 1)
+  }
+
+  test("DSL save") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "cars-copy.csv"
+
+    val cars = TestSQLContext.csvFile(carsFile, parserLib = "univocity")
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true"))
+
+    val carsCopy = TestSQLContext.csvFile(copyFilePath + "/")
+
+    assert(carsCopy.count == cars.count)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
+  }
+
+  test("DSL save with a compression codec") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "cars-copy.csv"
+
+    val cars = TestSQLContext.csvFile(carsFile, parserLib = "univocity")
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true"), classOf[GzipCodec])
+
+    val carsCopy = TestSQLContext.csvFile(copyFilePath + "/")
+
+    assert(carsCopy.count == cars.count)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
+  }
+
+  test("DSL save with quoting") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "cars-copy.csv"
+
+    val cars = TestSQLContext.csvFile(carsFile, parserLib = "univocity")
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "\""))
+
+    val carsCopy = TestSQLContext.csvFile(copyFilePath + "/", parserLib = "univocity")
+
+    assert(carsCopy.count == cars.count)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
+  }
+
+  test("DSL save with alternate quoting") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "cars-copy.csv"
+
+    val cars = TestSQLContext.csvFile(carsFile)
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "!"))
+
+    val carsCopy = TestSQLContext.csvFile(copyFilePath + "/", quote = '!', parserLib = "univocity")
+
+    assert(carsCopy.count == cars.count)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
+  }
+
+  test("DSL save with quoting, escaped quote") {
+    // Create temp directory
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+    val copyFilePath = tempEmptyDir + "escape-copy.csv"
+
+    val escape = TestSQLContext.csvFile(escapeFile, escape='|', quote='"')
+    escape.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "\""))
+
+    val escapeCopy = TestSQLContext.csvFile(copyFilePath + "/", parserLib = "univocity")
+
+    assert(escapeCopy.count == escape.count)
+    assert(escapeCopy.collect.map(_.toString).toSet == escape.collect.map(_.toString).toSet)
+    assert(escapeCopy.head().getString(0) == "\"thing")
+  }
+}

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -31,7 +31,7 @@ class CsvFastSuite extends FunSuite {
   val carsAltFile = "src/test/resources/cars-alternative.csv"
   val emptyFile = "src/test/resources/empty.csv"
   val escapeFile = "src/test/resources/escape.csv"
-  val tempEmptyDir = "target/test/empty/"
+  val tempEmptyDir = "target/test/empty2/"
 
   val numCars = 3
 

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -160,8 +160,6 @@ class CsvSuite extends FunSuite {
         |OPTIONS (path "$carsFile", header "true")
       """.stripMargin.replaceAll("\n", " "))
 
-    sql("select * from carsTable").collect().foreach { println(_) }
-
     assert(sql("SELECT makeName FROM carsTable").collect().size === numCars)
     assert(sql("SELECT avg(yearMade) FROM carsTable where grp = '' group by grp")
       .collect().head(0) === 2004.5)

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -160,9 +160,11 @@ class CsvSuite extends FunSuite {
         |OPTIONS (path "$carsFile", header "true")
       """.stripMargin.replaceAll("\n", " "))
 
+    sql("select * from carsTable").collect().foreach { println(_) }
+
     assert(sql("SELECT makeName FROM carsTable").collect().size === numCars)
-    assert(sql("SELECT avg(yearMade) FROM carsTable where grp = '' group by grp")
-      .collect().head(0) === 2004.5)
+    assert(sql("SELECT avg(yearMade) FROM carsTable where grp is null group by grp")
+      .collect().head(0) === 2008)
   }
 
   test("DSL column names test") {
@@ -213,7 +215,7 @@ class CsvSuite extends FunSuite {
     val carsCopy = TestSQLContext.csvFile(copyFilePath + "/")
 
     assert(carsCopy.count == cars.count)
-    assert(carsCopy.collect.map(_.toString).toSet== cars.collect.map(_.toString).toSet)
+    assert(carsCopy.collect.map(_.toString).toSet == cars.collect.map(_.toString).toSet)
   }
 
   test("DSL save with a compression codec") {

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -163,8 +163,8 @@ class CsvSuite extends FunSuite {
     sql("select * from carsTable").collect().foreach { println(_) }
 
     assert(sql("SELECT makeName FROM carsTable").collect().size === numCars)
-    assert(sql("SELECT avg(yearMade) FROM carsTable where grp is null group by grp")
-      .collect().head(0) === 2008)
+    assert(sql("SELECT avg(yearMade) FROM carsTable where grp = '' group by grp")
+      .collect().head(0) === 2004.5)
   }
 
   test("DSL column names test") {

--- a/src/test/scala/com/databricks/spark/csv/ReaderSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/ReaderSuite.scala
@@ -1,0 +1,125 @@
+/*
+* Copyright 2015 Ayasdi Inc
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+package com.databricks.spark.sql.readers
+
+import org.scalatest.FunSuite
+
+/**
+ * test cases for StringIteratorReader
+ */
+class ReaderSuite extends FunSuite {
+
+  def readAll(iter: Iterator[String]) = {
+    val reader = new StringIteratorReader(iter)
+    var c: Int = -1
+    val read = new scala.collection.mutable.StringBuilder()
+    do {
+      c = reader.read()
+      read.append(c.toChar)
+    } while (c != -1)
+
+    read.dropRight(1).toString
+  }
+
+  def readBufAll(iter: Iterator[String], bufSize: Int) = {
+    val reader = new StringIteratorReader(iter)
+    val cbuf = new Array[Char](bufSize)
+    val read = new scala.collection.mutable.StringBuilder()
+
+    var done = false
+    do {    //read all input one cbuf at a time
+      var numRead = 0
+      var n = 0
+      do {  //try to fill cbuf
+        var off = 0
+        var len = cbuf.length
+        n = reader.read(cbuf, off, len)
+
+        if (n != -1) {
+          off += n
+          len -= n
+        }
+
+        assert(len >= 0 && len <= cbuf.length)
+        assert(off >= 0 && off <= cbuf.length)
+        read.appendAll(cbuf.take(n))
+      } while (n > 0)
+      if(n != -1) {
+        numRead += n
+      } else {
+        done = true
+      }
+    } while(!done)
+
+    read.toString
+  }
+
+  test("Hygiene") {
+    val reader = new StringIteratorReader(List("").toIterator)
+    assert(reader.ready === true)
+    assert(reader.markSupported === false)
+    intercept[IllegalArgumentException] { reader.skip(1) }
+    intercept[IllegalArgumentException] { reader.mark(1) }
+    intercept[IllegalArgumentException] { reader.reset() }
+  }
+
+
+  test("Regular case") {
+    val input = List("This is a string", "This is another string", "Small", "", "\"quoted\"")
+    val read = readAll(input.toIterator)
+    assert(read === input.mkString("\n") ++ ("\n"))
+  }
+
+  test("Empty iter") {
+    val input = List[String]()
+    val read = readAll(input.toIterator)
+    assert(read === "")
+  }
+
+  test("Embedded new line") {
+    val input = List("This is a string", "This is another string", "Small\n", "", "\"quoted\"")
+    val read = readAll(input.toIterator)
+    assert(read === input.mkString("\n") ++ ("\n"))
+  }
+
+  test("Buffer Regular case") {
+    val input = List("This is a string", "This is another string", "Small", "", "\"quoted\"")
+    val output = input.mkString("\n") ++ ("\n")
+    for(i <- 1 to output.length + 5) {
+      val read = readBufAll(input.toIterator, i)
+      assert(read === output)
+    }
+  }
+
+  test("Buffer Empty iter") {
+    val input = List[String]()
+    val output = ""
+    for(i <- 1 to output.length + 5) {
+      val read = readBufAll(input.toIterator, 1)
+      assert(read === "")
+    }
+  }
+
+  test("Buffer Embedded new line") {
+    val input = List("This is a string", "This is another string", "Small\n", "", "\"quoted\"")
+    val output = input.mkString("\n") ++ ("\n")
+    for(i <- 1 to output.length + 5) {
+      val read = readBufAll(input.toIterator, 1)
+      assert(read === output)
+    }
+  }
+}


### PR DESCRIPTION
Right now one unit test is broken. 
The string
|"thing 
is parsed as 
|"thing
by univocity parser
but as 
"thing 

by common csv in the last unit test.

They are both right in their own way.

Reason for speedup --
1. Calling CSVParser.parse() creates a new CSVParser object and a new StringReader object for every line in the input CSV file. This is what I was initially doing in bigdf. So I wrote CsvReader which includes a way to parse a whole partition of data with a single parser. This required re-inserting the newline characters in the data which sc.textFile() removes. I think I do that quite efficiently, but there might be more optimizations that others can think of.
2. I also switched to using Univocity parser which is more efficient. I did some tests and found it twice as fast as Apace Commons CSV.
3. Univocity parser also supports more options for flexibility in parsing as well as performance tuning
4. Instead of "filtering" the header line (which bigdf started with as well), I now use iter.drop(1) on the first partition to skip the first line.

A functional change --
I changed the CSV writing code (which still uses common csv) to write the header to only the first partition. I believe this is correct as although the partitions may show up as different files in the filesystem they are logically a single file. We may coalesce or repartition them and in that case the headers will no longer be on the first line. 

