### PR TITLE
[Issue 65] Parsing CSV with '\t' in notebook fails

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,8 @@ libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.3.0" % "provided"
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
+libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.4"
+
 libraryDependencies += "com.univocity" % "univocity-parsers" % "1.5.1"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -15,6 +15,7 @@
  */
 package com.databricks.spark.csv
 
+import org.apache.commons.lang3.StringEscapeUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.sources._
@@ -49,7 +50,7 @@ class DefaultSource
       parameters: Map[String, String],
       schema: StructType) = {
     val path = checkPath(parameters)
-    val delimiter = parameters.getOrElse("delimiter", ",")
+    val delimiter = StringEscapeUtils.unescapeJava(parameters.getOrElse("delimiter", ","))
     val delimiterChar = if (delimiter.length == 1) {
       delimiter.charAt(0)
     } else {

--- a/src/test/resources/cars.tsv
+++ b/src/test/resources/cars.tsv
@@ -1,0 +1,4 @@
+year	make	model	comment	blank
+"2012"	"Tesla"	"S"	"No	comment"
+1997	Ford	E350	"Go	get one now they are going fast"
+2015	Chevy	Volt		

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -28,6 +28,7 @@ import TestSQLContext._
 
 class CsvSuite extends FunSuite {
   val carsFile = "src/test/resources/cars.csv"
+  val carsTsvFile = "src/test/resources/cars.tsv"
   val carsAltFile = "src/test/resources/cars-alternative.csv"
   val emptyFile = "src/test/resources/empty.csv"
   val escapeFile = "src/test/resources/escape.csv"
@@ -50,6 +51,17 @@ class CsvSuite extends FunSuite {
         |CREATE TEMPORARY TABLE carsTable
         |USING com.databricks.spark.csv
         |OPTIONS (path "$carsFile", header "true")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT year FROM carsTable").collect().size === numCars)
+  }
+
+  test("DDL test with tab separated file") {
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTable
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsTsvFile", header "true", delimiter "\t")
       """.stripMargin.replaceAll("\n", " "))
 
     assert(sql("SELECT year FROM carsTable").collect().size === numCars)
@@ -102,7 +114,8 @@ class CsvSuite extends FunSuite {
     assert(results.size === numCars)
   }
 
-  test("Expect parsing error with wrong delimiter settting using sparkContext.csvFile") {
+
+  test("Expect parsing error with wrong delimiter setting using sparkContext.csvFile") {
     intercept[ org.apache.spark.sql.AnalysisException] {
       TestSQLContext.csvFile(carsAltFile, useHeader = true, delimiter = ',', quote = '\'')
         .select("year")


### PR DESCRIPTION
We use apache commons-lang to unescape the delimiter string. Also added a unit test for this.

closes #65 