### PR TITLE
Manually unescape delimiter character instead of using commons-lang3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,8 +12,6 @@ crossScalaVersions := Seq("2.10.4", "2.11.6")
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
-libraryDependencies += "org.apache.commons" % "commons-lang3" % "3.4"
-
 libraryDependencies += "com.univocity" % "univocity-parsers" % "1.5.1"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -19,7 +19,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
-import com.databricks.spark.csv.util.ParserLibs
+import com.databricks.spark.csv.util.{ParserLibs, TypeCast}
 
 /**
  * Provides access to CSV data from pure SQL statements (i.e. for users of the
@@ -49,12 +49,7 @@ class DefaultSource
       parameters: Map[String, String],
       schema: StructType) = {
     val path = checkPath(parameters)
-    val delimiter = parameters.getOrElse("delimiter", ",")
-    val delimiterChar = if (delimiter.length == 1) {
-      delimiter.charAt(0)
-    } else {
-      throw new Exception("Delimiter cannot be more than one character.")
-    }
+    val delimiter = TypeCast.toChar(parameters.getOrElse("delimiter", ","))
 
     val quote = parameters.getOrElse("quote", "\"")
     val quoteChar = if (quote.length == 1) {
@@ -110,7 +105,7 @@ class DefaultSource
 
     CsvRelation(path,
       headerFlag,
-      delimiterChar,
+      delimiter,
       quoteChar,
       escapeChar,
       parseMode,

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -15,7 +15,6 @@
  */
 package com.databricks.spark.csv
 
-import org.apache.commons.lang3.StringEscapeUtils
 import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.sources._
@@ -50,7 +49,7 @@ class DefaultSource
       parameters: Map[String, String],
       schema: StructType) = {
     val path = checkPath(parameters)
-    val delimiter = StringEscapeUtils.unescapeJava(parameters.getOrElse("delimiter", ","))
+    val delimiter = parameters.getOrElse("delimiter", ",")
     val delimiterChar = if (delimiter.length == 1) {
       delimiter.charAt(0)
     } else {

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -68,13 +68,12 @@ object TypeCast {
         case '\"' => '\"'
         case '\'' => '\''
         case 'u' if str == """\u0000""" => '\u0000'
-        case '0' => '\0'
-        case _ => throw new RuntimeException(s"Unsupported special character for delimiter: $str")
+        case _ => throw new IllegalArgumentException(s"Unsupported special character for delimiter: $str")
       }
     } else if (str.length == 1) {
       str.charAt(0)
     } else {
-      throw new RuntimeException(s"Delimiter cannot be more than one character: $str")
+      throw new IllegalArgumentException(s"Delimiter cannot be more than one character: $str")
     }
   }
 }

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -57,6 +57,7 @@ object TypeCast {
    * character.
    *
    */
+  @throws[IllegalArgumentException]
   private[csv] def toChar(str: String): Char = {
     if (str.charAt(0) == '\\') {
       str.charAt(1)

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -50,4 +50,31 @@ object TypeCast {
       case _ => throw new RuntimeException(s"Unsupported type: ${castType.typeName}")
     }
   }
+
+  /**
+   * Helper method that converts string representation of a character to actual character.
+   * It handles some Java escaped strings and throws exception if given string is longer than one
+   * character.
+   *
+   */
+  private[csv] def toChar(str: String): Char = {
+    if (str.startsWith("\\")) {
+      str.charAt(1)
+       match {
+        case 't' => '\t'
+        case 'r' => '\r'
+        case 'b' => '\b'
+        case 'f' => '\f'
+        case '\"' => '\"'
+        case '\'' => '\''
+        case 'u' if str == "\u0000" => '\u0000'
+        case '0' => '\0'
+        case _ => throw new RuntimeException(s"Unsupported special character for delimiter: $str")
+      }
+    } else if (str.length == 1) {
+      str.charAt(0)
+    } else {
+      throw new RuntimeException(s"Delimiter cannot be more than one character: $str")
+    }
+  }
 }

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -69,7 +69,8 @@ object TypeCast {
         case '\"' => '\"'
         case '\'' => '\''
         case 'u' if str == """\u0000""" => '\u0000'
-        case _ => throw new IllegalArgumentException(s"Unsupported special character for delimiter: $str")
+        case _ =>
+          throw new IllegalArgumentException(s"Unsupported special character for delimiter: $str")
       }
     } else if (str.length == 1) {
       str.charAt(0)

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -67,7 +67,7 @@ object TypeCast {
         case 'f' => '\f'
         case '\"' => '\"'
         case '\'' => '\''
-        case 'u' if str == "\u0000" => '\u0000'
+        case 'u' if str == """\u0000""" => '\u0000'
         case '0' => '\0'
         case _ => throw new RuntimeException(s"Unsupported special character for delimiter: $str")
       }

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -58,7 +58,7 @@ object TypeCast {
    *
    */
   private[csv] def toChar(str: String): Char = {
-    if (str.startsWith("\\")) {
+    if (str.charAt(0) == '\\') {
       str.charAt(1)
        match {
         case 't' => '\t'

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -66,7 +66,7 @@ object TypeCast {
         case 'r' => '\r'
         case 'b' => '\b'
         case 'f' => '\f'
-        case '\"' => '\"'
+        case '\"' => '\"' // In case user changes quote char and uses \" as delimiter in options
         case '\'' => '\''
         case 'u' if str == """\u0000""" => '\u0000'
         case _ =>

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -33,8 +33,13 @@ class TypeCastSuite extends FunSuite {
     }
   }
 
-  test("Can parse escaped \t") {
-    val escapedStr = """\t"""
-    assert(TypeCast.toChar(escapedStr) === '\t')
+  test("Can parse escaped characters") {
+    assert(TypeCast.toChar("""\t""") === '\t')
+    assert(TypeCast.toChar("""\r""") === '\r')
+    assert(TypeCast.toChar("""\b""") === '\b')
+    assert(TypeCast.toChar("""\f""") === '\f')
+    assert(TypeCast.toChar("""\"""") === '\"')
+    assert(TypeCast.toChar("""\'""") === '\'')
+    assert(TypeCast.toChar("""\u0000""") === '\u0000')
   }
 }

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -42,4 +42,18 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.toChar("""\'""") === '\'')
     assert(TypeCast.toChar("""\u0000""") === '\u0000')
   }
+
+  test("Does not accept delimiter larger than one character") {
+    val exception = intercept[IllegalArgumentException]{
+      TypeCast.toChar("ab")
+    }
+    assert(exception.getMessage.contains("cannot be more than one character"))
+  }
+
+  test("Throws exception for unsupported escaped characters") {
+    val exception = intercept[IllegalArgumentException]{
+      TypeCast.toChar("""\1""")
+    }
+    assert(exception.getMessage.contains("Unsupported special character for delimiter"))
+  }
 }

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -32,4 +32,9 @@ class TypeCastSuite extends FunSuite {
       assert(TypeCast.castTo(strVal, decimalType) === new BigDecimal(decimalVal.toString))
     }
   }
+
+  test("Can parse escaped \t") {
+    val escapedStr = """\t"""
+    assert(TypeCast.toChar(escapedStr) === '\t')
+  }
 }


### PR DESCRIPTION
Instead of depending on commons-lang3 for unescaping java strings, we could manually construct important delimiter characters from the escaped string. 