### PR TITLE
Configurable null values

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -34,6 +34,7 @@ class CsvParser {
   private var ignoreLeadingWhiteSpace: Boolean = false
   private var ignoreTrailingWhiteSpace: Boolean = false
   private var parserLib: String = ParserLibs.DEFAULT
+  private var nullValues: Seq[String] = Seq("")
 
 
   def withUseHeader(flag: Boolean): CsvParser = {
@@ -81,6 +82,11 @@ class CsvParser {
     this
   }
 
+  def withNullValues(nullValues: Seq[String]): CsvParser = {
+    this.nullValues = nullValues
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -94,7 +100,8 @@ class CsvParser {
       parserLib,
       ignoreLeadingWhiteSpace,
       ignoreTrailingWhiteSpace,
-      schema)(sqlContext)
+      schema,
+      nullValues)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -41,7 +41,8 @@ case class CsvRelation protected[spark] (
     parserLib: String,
     ignoreLeadingWhiteSpace: Boolean,
     ignoreTrailingWhiteSpace: Boolean,
-    userSchema: StructType = null)(@transient val sqlContext: SQLContext)
+    userSchema: StructType = null,
+    nullValues: Seq[String] = Seq(""))(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with InsertableRelation {
 
   private val logger = LoggerFactory.getLogger(CsvRelation.getClass)
@@ -63,7 +64,7 @@ case class CsvRelation protected[spark] (
 
   // By making this a lazy val we keep the RDD around, amortizing the cost of locating splits.
   def buildScan = {
-    val baseRDD = sqlContext.sparkContext.textFile(location)
+    val baseRDD = sqlContext.sparkContext.textFile(location).map(line => line.replaceAll(nullValues.mkString("|"), ""))
 
     val fieldNames = schema.fieldNames
 

--- a/src/test/resources/missing-values.csv
+++ b/src/test/resources/missing-values.csv
@@ -1,0 +1,5 @@
+year,make,model,comment,blank
+"2012","Tesla","S","No comment",
+1997,Ford,E350,"Go get one now they are going fast",
+2015,Chevy,Volt
+NA,NULL,"T","Comment"

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -32,6 +32,7 @@ class CsvFastSuite extends FunSuite {
   val carsAltFile = "src/test/resources/cars-alternative.csv"
   val emptyFile = "src/test/resources/empty.csv"
   val escapeFile = "src/test/resources/escape.csv"
+  val carsWithNAs = "src/test/resources/missing-values.csv"
   val tempEmptyDir = "target/test/empty2/"
 
   val numCars = 3
@@ -91,6 +92,25 @@ class CsvFastSuite extends FunSuite {
       .collect()
 
     assert(results.size === numCars - 1)
+  }
+
+  test("DSL test for handling NULL values") {
+    val results = new CsvParser()
+      .withUseHeader(true)
+      .withParserLib("univocity")
+      .withNullValues(Seq("NULL", "NA"))
+      .csvFile(TestSQLContext, carsWithNAs)
+      .collect()
+
+    assert(results.size === numCars + 1)
+
+    val results2 = new CsvParser()
+      .withUseHeader(true)
+      .withNullValues(Seq("NULL", "NA", "NaN"))
+      .csvFile(TestSQLContext, carsWithNAs)
+      .collect()
+
+    assert(results2.size === numCars + 1)
   }
 
   test("DSL test for FAILFAST parsing mode") {


### PR DESCRIPTION
There's datasets where each column has it's own marker for missing values. spark-csv assumes only empty string for missing values. To avoid additional data transformation and saving on user's side would be great to specify a set of null markers and replace them to empty string on a library side. 