### PR TITLE
Increase default max chars per column

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvReader.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvReader.scala
@@ -56,6 +56,7 @@ private[readers] abstract class CsvReader(fieldSep: Char = ',',
     settings.setInputBufferSize(inputBufSize)
     settings.setMaxColumns(maxCols)
     settings.setNullValue("")
+    settings.setMaxCharsPerColumn(100000)
     if(headers != null) settings.setHeaders(headers:_*)
 
     new CsvParser(settings)


### PR DESCRIPTION
For textual data (e.g. sentiment analysis csv - paragraph, score) default univocity limit of max chars per column of 4096 is not enough. It should be configurable, but since this setting is only for univocity parser, could be hardcoded.