### PR TITLE
handle file encodings other than utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ When reading files the API accepts several options:
   * `PERMISSIVE`: tries to parse all lines: nulls are inserted for missing tokens and extra tokens are ignored.
   * `DROPMALFORMED`: drops lines which have fewer or more tokens than expected
   * `FAILFAST`: aborts with a RuntimeException if encounters any malformed line
+* `charset`: defaults to 'UTF-8' but can be set to other valid charset names
 
 The package also support saving simple (non-nested) DataFrame. When saving you can specify the delimiter and whether we should generate a header row for the table. See following examples for more details.
 

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -18,7 +18,7 @@ package com.databricks.spark.csv
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.types.StructType
-import com.databricks.spark.csv.util.{ParserLibs, ParseModes}
+import com.databricks.spark.csv.util.{ParserLibs, ParseModes, TextFile}
 
 /**
  * A collection of static functions for working with CSV files in Spark SQL
@@ -34,7 +34,7 @@ class CsvParser {
   private var ignoreLeadingWhiteSpace: Boolean = false
   private var ignoreTrailingWhiteSpace: Boolean = false
   private var parserLib: String = ParserLibs.DEFAULT
-  private var charset: String = DefaultCharset
+  private var charset: String = TextFile.DEFAULT_CHARSET.name()
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -34,7 +34,7 @@ class CsvParser {
   private var ignoreLeadingWhiteSpace: Boolean = false
   private var ignoreTrailingWhiteSpace: Boolean = false
   private var parserLib: String = ParserLibs.DEFAULT
-
+  private var charset: String = DefaultCharset
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -81,6 +81,11 @@ class CsvParser {
     this
   }
 
+  def withCharset(charset: String): CsvParser = {
+    this.charset = charset
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -94,7 +99,8 @@ class CsvParser {
       parserLib,
       ignoreLeadingWhiteSpace,
       ignoreTrailingWhiteSpace,
-      schema)(sqlContext)
+      schema,
+      charset)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -17,14 +17,13 @@ package com.databricks.spark.csv
 
 import java.io.IOException
 
-import org.apache.hadoop.io.{Text, LongWritable}
-import org.apache.hadoop.mapred.TextInputFormat
-
 import scala.collection.JavaConversions._
 import scala.util.control.NonFatal
 
 import org.apache.commons.csv._
 import org.apache.hadoop.fs.Path
+import org.apache.hadoop.io.{Text, LongWritable}
+import org.apache.hadoop.mapred.TextInputFormat
 import org.slf4j.LoggerFactory
 
 import org.apache.spark.rdd.RDD

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -102,6 +102,8 @@ class DefaultSource
       throw new Exception("Ignore white space flag can be true or false")
     }
 
+    val charset = parameters.getOrElse("charset", DefaultCharset)
+    // TODO validate charset?
 
     CsvRelation(path,
       headerFlag,
@@ -112,7 +114,8 @@ class DefaultSource
       parserLib,
       ignoreLeadingWhiteSpaceFlag,
       ignoreTrailingWhiteSpaceFlag,
-      schema)(sqlContext)
+      schema,
+      charset)(sqlContext)
   }
 
   override def createRelation(

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -19,7 +19,7 @@ import org.apache.hadoop.fs.Path
 import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
-import com.databricks.spark.csv.util.{ParserLibs, TypeCast}
+import com.databricks.spark.csv.util.{ParserLibs, TextFile, TypeCast}
 
 /**
  * Provides access to CSV data from pure SQL statements (i.e. for users of the
@@ -102,7 +102,7 @@ class DefaultSource
       throw new Exception("Ignore white space flag can be true or false")
     }
 
-    val charset = parameters.getOrElse("charset", DefaultCharset)
+    val charset = parameters.getOrElse("charset", TextFile.DEFAULT_CHARSET.name())
     // TODO validate charset?
 
     CsvRelation(path,

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -19,10 +19,9 @@ import org.apache.commons.csv.CSVFormat
 import org.apache.hadoop.io.compress.CompressionCodec
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
+import com.databricks.spark.csv.util.TextFile
 
 package object csv {
-
-  val DefaultCharset = "UTF-8"
 
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.
@@ -37,7 +36,7 @@ package object csv {
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
                 ignoreTrailingWhiteSpace: Boolean = false,
-                charset: String = DefaultCharset) = {
+                charset: String = TextFile.DEFAULT_CHARSET.name()) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
@@ -57,7 +56,7 @@ package object csv {
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
                 ignoreTrailingWhiteSpace: Boolean = false,
-                charset: String = DefaultCharset) = {
+                charset: String = TextFile.DEFAULT_CHARSET.name()) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -22,6 +22,8 @@ import org.apache.spark.sql.{DataFrame, SQLContext}
 
 package object csv {
 
+  val DefaultCharset = "UTF-8"
+
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.
    */
@@ -34,7 +36,8 @@ package object csv {
                 mode: String = "PERMISSIVE",
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
-                ignoreTrailingWhiteSpace: Boolean = false) = {
+                ignoreTrailingWhiteSpace: Boolean = false,
+                charset: String = DefaultCharset) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
@@ -44,7 +47,8 @@ package object csv {
         parseMode = mode,
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
-        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
+        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
+        charset = charset)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
@@ -52,7 +56,8 @@ package object csv {
                 useHeader: Boolean = true,
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
-                ignoreTrailingWhiteSpace: Boolean = false) = {
+                ignoreTrailingWhiteSpace: Boolean = false,
+                charset: String = DefaultCharset) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
@@ -62,7 +67,8 @@ package object csv {
         parseMode = "PERMISSIVE",
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
-        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
+        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
+        charset = charset)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -1,0 +1,24 @@
+package com.databricks.spark.csv.util
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+import org.apache.hadoop.io.{Text, LongWritable}
+import org.apache.hadoop.mapred.TextInputFormat
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
+
+private[csv] object TextFile {
+  val DEFAULT_CHARSET = StandardCharsets.UTF_8
+
+  def withCharset(context: SparkContext, location: String, charset: String): RDD[String] = {
+    if (Charset.forName(charset) == DEFAULT_CHARSET) {
+      context.textFile(location)
+    } else {
+      // can't pass a Charset object here cause its not serializable
+      // TODO: maybe use mapPartitions instead?
+      context.hadoopFile[LongWritable, Text, TextInputFormat](location).map(
+        pair => new String(pair._2.getBytes, 0, pair._2.getLength, charset)
+      )
+    }
+  }
+}

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.databricks.spark.csv.util
 
 import java.nio.charset.{Charset, StandardCharsets}

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -15,7 +15,7 @@
  */
 package com.databricks.spark.csv.util
 
-import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.charset.Charset
 
 import org.apache.hadoop.io.{Text, LongWritable}
 import org.apache.hadoop.mapred.TextInputFormat
@@ -23,7 +23,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
 private[csv] object TextFile {
-  val DEFAULT_CHARSET = StandardCharsets.UTF_8
+  val DEFAULT_CHARSET = Charset.forName("UTF-8")
 
   def withCharset(context: SparkContext, location: String, charset: String): RDD[String] = {
     if (Charset.forName(charset) == DEFAULT_CHARSET) {

--- a/src/test/resources/cars_iso-8859-1.csv
+++ b/src/test/resources/cars_iso-8859-1.csv
@@ -1,0 +1,6 @@
+yearşmakeşmodelşcommentşblank
+"2012"ş"Tesla"ş"S"ş"No comment"ş
+
+1997şFordşE350ş"Go get one now they are şoing fast"ş
+2015şChevyşVolt
+

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -15,7 +15,8 @@
  */
 package com.databricks.spark.csv
 
-import java.io.{UnsupportedEncodingException, File}
+import java.io.File
+import java.nio.charset.UnsupportedCharsetException
 
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.test._
@@ -57,7 +58,7 @@ class CsvFastSuite extends FunSuite {
   }
 
   test("DSL test bad charset name") {
-    val exception = intercept[SparkException] {
+    val exception = intercept[UnsupportedCharsetException] {
       val results = TestSQLContext
         .csvFile(carsFile8859, parserLib = "univocity", charset = "1-9588-osi")
         .select("year")

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -15,7 +15,7 @@
  */
 package com.databricks.spark.csv
 
-import java.io.File
+import java.io.{UnsupportedEncodingException, File}
 
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.test._
@@ -28,6 +28,7 @@ import TestSQLContext._
 
 class CsvFastSuite extends FunSuite {
   val carsFile = "src/test/resources/cars.csv"
+  val carsFile8859 = "src/test/resources/cars_iso-8859-1.csv"
   val carsTsvFile = "src/test/resources/cars.tsv"
   val carsAltFile = "src/test/resources/cars-alternative.csv"
   val emptyFile = "src/test/resources/empty.csv"
@@ -45,12 +46,43 @@ class CsvFastSuite extends FunSuite {
     assert(results.size === numCars)
   }
 
+  test("DSL test for iso-8859-1 encoded file") {
+    val dataFrame = TestSQLContext
+      .csvFile(carsFile8859, parserLib = "univocity", charset  = "iso-8859-1", delimiter = 'þ')
+
+    assert(dataFrame.select("year").collect().size === numCars)
+
+    val results = dataFrame.select("comment", "year").where(dataFrame("year") === "1997")
+    assert(results.first.getString(0) === "Go get one now they are þoing fast")
+  }
+
+  test("DSL test bad charset name") {
+    val exception = intercept[SparkException] {
+      val results = TestSQLContext
+        .csvFile(carsFile8859, parserLib = "univocity", charset = "1-9588-osi")
+        .select("year")
+        .collect()
+    }
+    assert(exception.getMessage.contains("1-9588-osi"))
+  }
+
   test("DDL test") {
     sql(
       s"""
          |CREATE TEMPORARY TABLE carsTable
          |USING com.databricks.spark.csv
          |OPTIONS (path "$carsFile", header "true", parserLib "univocity")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT year FROM carsTable").collect().size === numCars)
+  }
+
+  test("DDL test with charset") {
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTable
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsFile8859", header "true", parserLib "univocity", charset "iso-8859-1", delimiter "þ")
       """.stripMargin.replaceAll("\n", " "))
 
     assert(sql("SELECT year FROM carsTable").collect().size === numCars)

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -15,7 +15,7 @@
  */
 package com.databricks.spark.csv
 
-import java.io.File
+import java.io.{File}
 
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.test._
@@ -28,6 +28,7 @@ import TestSQLContext._
 
 class CsvSuite extends FunSuite {
   val carsFile = "src/test/resources/cars.csv"
+  val carsFile8859 = "src/test/resources/cars_iso-8859-1.csv"
   val carsTsvFile = "src/test/resources/cars.tsv"
   val carsAltFile = "src/test/resources/cars-alternative.csv"
   val emptyFile = "src/test/resources/empty.csv"
@@ -43,6 +44,33 @@ class CsvSuite extends FunSuite {
       .collect()
 
     assert(results.size === numCars)
+  }
+
+  test("DSL test for iso-8859-1 encoded file") {
+    val dataFrame = new CsvParser()
+      .withUseHeader(true)
+      .withCharset("iso-8859-1")
+      .withDelimiter('þ')
+      .csvFile(TestSQLContext, carsFile8859)
+
+    assert(dataFrame.select("year").collect().size === numCars)
+
+    val results = dataFrame.select("comment", "year").where(dataFrame("year") === "1997")
+    assert(results.first.getString(0) === "Go get one now they are þoing fast")
+  }
+
+  test("DSL test for bad charset name") {
+    val parser = new CsvParser()
+      .withUseHeader(true)
+      .withCharset("1-9588-osi")
+
+    val exception = intercept[SparkException] {
+      parser.csvFile(TestSQLContext, carsFile)
+        .select("year")
+        .collect()
+    }
+
+    assert(exception.getMessage.contains("1-9588-osi"))
   }
 
   test("DDL test") {
@@ -159,6 +187,16 @@ class CsvSuite extends FunSuite {
     assert(sql("SELECT year FROM carsTable").collect().size === numCars)
   }
 
+  test("DDL test with charset") {
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTable
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsFile8859", header "true", delimiter "þ", charset "iso-8859-1")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sql("SELECT year FROM carsTable").collect().size === numCars)
+  }
 
   test("DSL test with empty file and known schema") {
     val results = new CsvParser()

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -15,7 +15,7 @@
  */
 package com.databricks.spark.csv
 
-import java.io.{File}
+import java.io.File
 
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.test._

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -16,6 +16,7 @@
 package com.databricks.spark.csv
 
 import java.io.File
+import java.nio.charset.UnsupportedCharsetException
 
 import org.apache.hadoop.io.compress.GzipCodec
 import org.apache.spark.sql.test._
@@ -64,7 +65,7 @@ class CsvSuite extends FunSuite {
       .withUseHeader(true)
       .withCharset("1-9588-osi")
 
-    val exception = intercept[SparkException] {
+    val exception = intercept[UnsupportedCharsetException] {
       parser.csvFile(TestSQLContext, carsFile)
         .select("year")
         .collect()

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -15,7 +15,7 @@
  */
 package com.databricks.spark.csv.util
 
-import java.nio.charset.{UnsupportedCharsetException, StandardCharsets}
+import java.nio.charset.UnsupportedCharsetException
 
 import org.apache.spark.sql.test.TestSQLContext
 import org.scalatest.FunSuite
@@ -26,8 +26,8 @@ class TextFileSuite extends FunSuite {
   val numLines = 6
   val numColumns = 4
   val smallThorn = '\u00fe' //non-ascii character
-  val utf8 = StandardCharsets.UTF_8.name()
-  val iso88591 = StandardCharsets.ISO_8859_1.name()
+  val utf8 = "utf-8"
+  val iso88591 = "iso-8859-1"
 
   test("read utf-8 encoded file") {
     val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile, utf8)

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.csv.util
+
+import java.nio.charset.{UnsupportedCharsetException, StandardCharsets}
+
+import org.apache.spark.sql.test.TestSQLContext
+import org.scalatest.FunSuite
+
+class TextFileSuite extends FunSuite {
+  val carsFile = "src/test/resources/cars.csv"
+  val carsFile8859 = "src/test/resources/cars_iso-8859-1.csv"
+  val numLines = 6
+  val numColumns = 4
+  val smallThorn = '\u00fe' //non-ascii character
+  val utf8 = StandardCharsets.UTF_8.name()
+  val iso88591 = StandardCharsets.ISO_8859_1.name()
+
+  test("read utf-8 encoded file") {
+    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile, utf8)
+    assert(baseRDD.count() === numLines)
+    assert(baseRDD.first().count(_ == ',') == numColumns)
+  }
+
+  test("read utf-8 encoded file using charset alias") {
+    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile, "utf8")
+    assert(baseRDD.count() === numLines)
+    assert(baseRDD.first().count(_ == ',') == numColumns)
+  }
+
+  test("read iso-8859-1 encoded file") {
+    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile8859, iso88591)
+    assert(baseRDD.count() === numLines)
+    assert(baseRDD.first().count(_ == smallThorn) == numColumns)
+  }
+
+  test("read iso-8859-1 encoded file using charset alias") {
+    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile8859, "8859_1")
+    assert(baseRDD.count() === numLines)
+    assert(baseRDD.first().count(_ == smallThorn) == numColumns)
+  }
+
+  test("read iso-8859-1 encoded file with invalid charset") {
+    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile8859, utf8)
+    assert(baseRDD.count() === numLines)
+    // file loads but since it's not encoded in utf-8, non-ascii characters are not decoded
+    // correctly.
+    assert(baseRDD.first().count(_ == smallThorn) == 0)
+  }
+
+  test("unsupported charset") {
+    val exception = intercept[UnsupportedCharsetException] {
+      TextFile.withCharset(TestSQLContext.sparkContext, carsFile, "frylock").count()
+    }
+    assert(exception.getMessage.contains("frylock"))
+  }
+}


### PR DESCRIPTION
Add support for different file encodings which can be useful when dealing with CSV files from the wild. In our case, we had 8859-1 files containing "þ" which doesn't work with UTF-8. The core of the fix is to add a 'charset' option which defaults to 'UTF-8'. For values other than 'UTF-8', call `SparkContext.hadoopFile()` instead of `SparkContext.textFile()` and translate the `hadoop.io.Text` object to a string based on the specified encoding. Inspiration for this workaround comes from: 

http://stackoverflow.com/questions/15883895/textinputformat-vs-non-utf-8-encoding

This change is only applicable to reading files. I do not think its a good idea to support different charsets when writing files