### PR TITLE
#60 provide type for custom columns

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -17,7 +17,7 @@ package com.databricks.spark.csv
 
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{DataType, StructType}
 import com.databricks.spark.csv.util.{ParserLibs, ParseModes}
 
 /**
@@ -34,6 +34,7 @@ class CsvParser {
   private var ignoreLeadingWhiteSpace: Boolean = false
   private var ignoreTrailingWhiteSpace: Boolean = false
   private var parserLib: String = ParserLibs.DEFAULT
+  private var columnsTypeMap: Map[String, DataType] = Map.empty
 
 
   def withUseHeader(flag: Boolean): CsvParser = {
@@ -81,6 +82,11 @@ class CsvParser {
     this
   }
 
+  def withTypedFields(columnsTypeMap: Map[String, DataType]): CsvParser = {
+    this.columnsTypeMap = columnsTypeMap
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -94,7 +100,8 @@ class CsvParser {
       parserLib,
       ignoreLeadingWhiteSpace,
       ignoreTrailingWhiteSpace,
-      schema)(sqlContext)
+      schema,
+      columnsTypeMap)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources.{BaseRelation, InsertableRelation, TableScan}
-import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.sql.types.{DataType, StringType, StructField, StructType}
 import com.databricks.spark.csv.util.{ParserLibs, ParseModes, TypeCast}
 import com.databricks.spark.sql.readers._
 
@@ -41,7 +41,8 @@ case class CsvRelation protected[spark] (
     parserLib: String,
     ignoreLeadingWhiteSpace: Boolean,
     ignoreTrailingWhiteSpace: Boolean,
-    userSchema: StructType = null)(@transient val sqlContext: SQLContext)
+    userSchema: StructType = null,
+    columnsTypeMap: Map[String, DataType] = Map.empty)(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with InsertableRelation {
 
   private val logger = LoggerFactory.getLogger(CsvRelation.getClass)
@@ -115,7 +116,7 @@ case class CsvRelation protected[spark] (
       }
       // By default fields are assumed to be StringType
       val schemaFields = header.map { fieldName =>
-        StructField(fieldName.toString, StringType, nullable = true)
+        StructField(fieldName.toString, columnsTypeMap.getOrElse(fieldName, StringType), nullable = true)
       }
       StructType(schemaFields)
     }

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -17,6 +17,7 @@ package com.databricks.spark
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.hadoop.io.compress.CompressionCodec
+import org.apache.spark.sql.types.DataType
 
 import org.apache.spark.sql.{DataFrame, SQLContext}
 
@@ -26,7 +27,9 @@ package object csv {
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.
    */
   implicit class CsvContext(sqlContext: SQLContext) {
+
     def csvFile(filePath: String,
+                columnsTypeMap: Map[String, DataType] = Map.empty,
                 useHeader: Boolean = true,
                 delimiter: Char = ',',
                 quote: Char = '"',
@@ -44,7 +47,8 @@ package object csv {
         parseMode = mode,
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
-        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
+        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
+        columnsTypeMap = columnsTypeMap)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 

--- a/src/test/resources/cars-typed-fail.csv
+++ b/src/test/resources/cars-typed-fail.csv
@@ -1,0 +1,6 @@
+year,make,model,comment,price,new,blank
+"2012","Tesla","S","No comment",900X00.00,false
+
+1997,Ford,E350,"Go get one now they are going fast",23000,true,
+2015,Chevy,Volt,,40000X.6767,false
+

--- a/src/test/resources/cars-typed.csv
+++ b/src/test/resources/cars-typed.csv
@@ -1,0 +1,6 @@
+year,make,model,comment,price,new,blank
+"2012","Tesla","S","No comment",90000.00,false
+
+1997,Ford,E350,"Go get one now they are going fast",23000,true,
+2015,Chevy,Volt,,40000.6767,false
+


### PR DESCRIPTION
If you are not using userSchema by default all fields in csv file are assumed to be StringType.
This commit adds possibility to setup types for fields which are not supposed to be as StringType.

Usage:

TestSQLContext.csvFile(carsTypedColumnsFile, fieldsTypeMap = Map("price" -> DoubleType, "new" -> BooleanType))