### PR TITLE
Add schema inference

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -82,7 +82,7 @@
  <!-- </check> -->
  <check level="error" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
   <parameters>
-   <parameter name="maxParameters"><![CDATA[10]]></parameter>
+   <parameter name="maxParameters"><![CDATA[11]]></parameter>
   </parameters>
  </check>
  <!-- <check level="error" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="true"> -->

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -35,6 +35,7 @@ class CsvParser {
   private var ignoreTrailingWhiteSpace: Boolean = false
   private var parserLib: String = ParserLibs.DEFAULT
   private var charset: String = TextFile.DEFAULT_CHARSET.name()
+  private var inferSchema: Boolean = false
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -86,6 +87,11 @@ class CsvParser {
     this
   }
 
+  def withInferSchema(inferSchema: Boolean) = {
+    this.inferSchema = inferSchema
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -100,7 +106,8 @@ class CsvParser {
       ignoreLeadingWhiteSpace,
       ignoreTrailingWhiteSpace,
       schema,
-      charset)(sqlContext)
+      charset,
+      inferSchema)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -90,12 +90,10 @@ case class CsvRelation protected[spark] (
         parseCSV(csvIter, csvFormat)
       }
     }
-
   }
 
   // By making this a lazy val we keep the RDD around, amortizing the cost of locating splits.
   def buildScan = {
-
     val schemaFields = schema.fields
     tokenRdd(schemaFields.map(_.name)).flatMap{ tokens =>
 
@@ -124,15 +122,12 @@ case class CsvRelation protected[spark] (
         }
       }
     }
-
   }
 
   private def inferSchema(): StructType = {
-
     if (this.userSchema != null) {
       userSchema
     } else {
-
       val firstRow = if(ParserLibs.isUnivocityLib(parserLib)) {
         val escapeVal = if(escape == null) '\\' else escape.charValue()
         new LineCsvReader(fieldSep = delimiter, quote = quote, escape = escapeVal)
@@ -145,13 +140,11 @@ case class CsvRelation protected[spark] (
           .withSkipHeaderRecord(false)
         CSVParser.parse(firstLine, csvFormat).getRecords.head.toArray
       }
-
       val header = if (useHeader) {
         firstRow
       } else {
         firstRow.zipWithIndex.map { case (value, index) => s"C$index"}
       }
-
       if (this.inferCsvSchema) {
         InferSchema(tokenRdd(header), header)
       } else{

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -116,9 +116,6 @@ case class CsvRelation protected[spark] (
           case aiob: ArrayIndexOutOfBoundsException if permissive =>
             (index until schemaFields.length).foreach(ind => rowArray(ind) = null)
             Some(Row.fromSeq(rowArray))
-          case NonFatal(e) if !failFast =>
-            logger.error(s"Exception while parsing line: $tokens. ", e)
-            None
         }
       }
     }

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -105,6 +105,15 @@ class DefaultSource
     val charset = parameters.getOrElse("charset", TextFile.DEFAULT_CHARSET.name())
     // TODO validate charset?
 
+    val inferSchema = parameters.getOrElse("inferSchema", "false")
+    val inferSchemaFlag = if(inferSchema == "false") {
+      false
+    } else if(inferSchema == "true") {
+      true
+    } else {
+      throw new Exception("Infer schema flag can be true or false")
+    }
+
     CsvRelation(path,
       headerFlag,
       delimiter,
@@ -115,7 +124,8 @@ class DefaultSource
       ignoreLeadingWhiteSpaceFlag,
       ignoreTrailingWhiteSpaceFlag,
       schema,
-      charset)(sqlContext)
+      charset,
+      inferSchemaFlag)(sqlContext)
   }
 
   override def createRelation(

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -36,7 +36,8 @@ package object csv {
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
                 ignoreTrailingWhiteSpace: Boolean = false,
-                charset: String = TextFile.DEFAULT_CHARSET.name()) = {
+                charset: String = TextFile.DEFAULT_CHARSET.name(),
+                inferSchema: Boolean = false) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
@@ -47,7 +48,8 @@ package object csv {
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
-        charset = charset)(sqlContext)
+        charset = charset,
+        inferCsvSchema = inferSchema)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
@@ -56,7 +58,8 @@ package object csv {
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
                 ignoreTrailingWhiteSpace: Boolean = false,
-                charset: String = TextFile.DEFAULT_CHARSET.name()) = {
+                charset: String = TextFile.DEFAULT_CHARSET.name(),
+                inferSchema: Boolean = false) = {
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
@@ -67,7 +70,8 @@ package object csv {
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
-        charset = charset)(sqlContext)
+        charset = charset,
+        inferCsvSchema = inferSchema)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.databricks.spark.csv.util
 
 import org.apache.spark.rdd.RDD
@@ -22,13 +37,14 @@ private[csv] object InferSchema {
     val rootTypes: Array[DataType] = tokenRdd.map { tokens =>
       tokens.map(inferField)
     }.treeReduce {
-      case (firstTypeArray, secondTypeArray) => firstTypeArray.zipAll(secondTypeArray, NullType, NullType).map { case ((a, b)) =>
-        val tpe = HiveTypeCoercion.findTightestCommonType(a, b).getOrElse(StringType)
-        tpe match {
-          case _: NullType => StringType
-          case other => other
+      case (firstTypeArray, secondTypeArray) =>
+        firstTypeArray.zipAll(secondTypeArray, NullType, NullType).map { case ((a, b)) =>
+          val tpe = HiveTypeCoercion.findTightestCommonType(a, b).getOrElse(StringType)
+          tpe match {
+            case _: NullType => StringType
+            case other => other
+          }
         }
-      }
     }
 
     val stuctFields = header.zip(rootTypes).map { case (thisHeader, rootType) =>

--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -1,0 +1,57 @@
+package com.databricks.spark.csv.util
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion
+import org.apache.spark.sql.types._
+
+import scala.util.control.Exception._
+
+private[csv] object InferSchema {
+
+  /**
+   * Similar to the JSON schema inference. {@link org.apache.spark.sql.json.InferSchema}
+   *     1. Infer type of each row
+   *     2. Merge row types to find common type
+   *     3. Replace any null types with string type
+   */
+  def apply(
+             tokenRdd: RDD[Array[String]],
+             header: Array[String]
+             ): StructType = {
+
+    val rootTypes: Array[DataType] = tokenRdd.map { tokens =>
+      tokens.map(inferField)
+    }.treeReduce {
+      case (firstTypeArray, secondTypeArray) => firstTypeArray.zipAll(secondTypeArray, NullType, NullType).map { case ((a, b)) =>
+        val tpe = HiveTypeCoercion.findTightestCommonType(a, b).getOrElse(StringType)
+        tpe match {
+          case _: NullType => StringType
+          case other => other
+        }
+      }
+    }
+
+    val stuctFields = header.zip(rootTypes).map { case (thisHeader, rootType) =>
+      StructField(thisHeader, rootType, nullable = true)
+    }
+
+    StructType(stuctFields)
+  }
+
+  private[csv] def inferField(field: String): DataType = {
+
+    if (field == null || field.isEmpty) {
+      NullType
+    } else if ((allCatch opt field.toInt).isDefined) {
+      IntegerType
+    } else if ((allCatch opt field.toLong).isDefined) {
+      LongType
+    } else if ((allCatch opt field.toDouble).isDefined) {
+      DoubleType
+    } else {
+      StringType
+    }
+
+  }
+
+}

--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -23,7 +23,7 @@ import scala.util.control.Exception._
 private[csv] object InferSchema {
 
   /**
-   * Similar to the JSON schema inference. {@link org.apache.spark.sql.json.InferSchema}
+   * Similar to the JSON schema inference. [[org.apache.spark.sql.json.InferSchema]]
    *     1. Infer type of each row
    *     2. Merge row types to find common type
    *     3. Replace any null types with string type
@@ -92,7 +92,7 @@ private[csv] object InferSchema {
 
   /**
    * Copied from internal Spark api
-   * {@link org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion}
+   * [[org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion]]
    */
   private val numericPrecedence =
     IndexedSeq(
@@ -106,7 +106,7 @@ private[csv] object InferSchema {
 
   /**
    * Copied from internal Spark api
-   * {@link org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion}
+   * [[org.apache.spark.sql.catalyst.analysis.HiveTypeCoercion]]
    */
   val findTightestCommonType: (DataType, DataType) => Option[DataType] = {
     case (t1, t2) if t1 == t2 => Some(t1)

--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -118,10 +118,6 @@ private[csv] object InferSchema {
       val index = numericPrecedence.lastIndexWhere(t => t == t1 || t == t2)
       Some(numericPrecedence(index))
 
-    // Fixed-precision decimals can up-cast into unlimited
-    case (DecimalType.Unlimited, _: DecimalType) => Some(DecimalType.Unlimited)
-    case (_: DecimalType, DecimalType.Unlimited) => Some(DecimalType.Unlimited)
-
     case _ => None
   }
 }

--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -28,10 +28,7 @@ private[csv] object InferSchema {
    *     2. Merge row types to find common type
    *     3. Replace any null types with string type
    */
-  def apply(
-             tokenRdd: RDD[Array[String]],
-             header: Array[String]
-             ): StructType = {
+  def apply(tokenRdd: RDD[Array[String]], header: Array[String]): StructType = {
 
     val rootTypes: Array[DataType] = tokenRdd.map { tokens =>
       tokens.map(inferField)
@@ -103,5 +100,4 @@ private[csv] object InferSchema {
 
     case _ => None
   }
-
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -387,5 +387,4 @@ class CsvFastSuite extends FunSuite {
     assert(results.first().getInt(0) === 1997)
 
   }
-
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -390,5 +390,4 @@ class CsvSuite extends FunSuite {
     assert(results.first().getInt(0) === 1997)
 
   }
-
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -343,4 +343,52 @@ class CsvSuite extends FunSuite {
     assert(escapeCopy.collect.map(_.toString).toSet == escape.collect.map(_.toString).toSet)
     assert(escapeCopy.head().getString(0) == "\"thing")
   }
+
+
+  test("DSL test schema inferred correctly") {
+
+    val results = TestSQLContext
+      .csvFile(carsFile, inferSchema = true)
+
+    assert(results.schema == StructType(List(
+      StructField("year",IntegerType,true),
+      StructField("make",StringType,true),
+      StructField("model",StringType,true),
+      StructField("comment",StringType,true),
+      StructField("blank",StringType,true))
+    ))
+
+    assert(results.collect().size === numCars)
+
+  }
+
+  test("DSL test inferred schema passed through") {
+
+    val dataFrame = TestSQLContext
+      .csvFile(carsFile, inferSchema = true)
+
+    val results = dataFrame
+      .select("comment", "year")
+      .where(dataFrame("year") === 2012)
+
+    assert(results.first.getString(0) === "No comment")
+    assert(results.first.getInt(1) === 2012)
+
+  }
+
+  test("DDL test with inferred schema") {
+
+    sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTable
+         |USING com.databricks.spark.csv
+         |OPTIONS (path "$carsFile", header "true", inferSchema "true")
+      """.stripMargin.replaceAll("\n", " "))
+
+    val results = sql("select year from carsTable where make = 'Ford'")
+
+    assert(results.first().getInt(0) === 1997)
+
+  }
+
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -347,8 +347,10 @@ class CsvSuite extends FunSuite {
 
   test("DSL test schema inferred correctly") {
 
-    val results = TestSQLContext
-      .csvFile(carsFile, inferSchema = true)
+    val results = new CsvParser()
+      .withInferSchema(true)
+      .withUseHeader(true)
+      .csvFile(TestSQLContext, carsFile)
 
     assert(results.schema == StructType(List(
       StructField("year",IntegerType,true),

--- a/src/test/scala/com/databricks/spark/csv/util/InferSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/InferSchemaSuite.scala
@@ -19,5 +19,13 @@ class InferSchemaSuite extends FunSuite {
     assert(InferSchema.inferField(LongType, "test") == StringType)
     assert(InferSchema.inferField(IntegerType, "1.0") == DoubleType)
     assert(InferSchema.inferField(DoubleType, null) == DoubleType)
+    assert(InferSchema.inferField(DoubleType, "test") == StringType)
   }
+
+  test("Type arrays are merged to highest common type"){
+    assert(InferSchema.mergeRowTypes(Array(StringType), Array(DoubleType)).deep == Array(StringType).deep)
+    assert(InferSchema.mergeRowTypes(Array(IntegerType), Array(LongType)).deep == Array(LongType).deep)
+    assert(InferSchema.mergeRowTypes(Array(DoubleType), Array(LongType)).deep == Array(DoubleType).deep)
+  }
+
 }

--- a/src/test/scala/com/databricks/spark/csv/util/InferSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/InferSchemaSuite.scala
@@ -1,0 +1,19 @@
+package com.databricks.spark.csv.util
+
+import org.apache.spark.sql.types._
+import org.scalatest.FunSuite
+
+class InferSchemaSuite extends FunSuite {
+
+  test("String fields types are inferred correctly"){
+
+    assert(InferSchema.inferField("") == NullType)
+    assert(InferSchema.inferField(null) == NullType)
+    assert(InferSchema.inferField("100000000000") == LongType)
+    assert(InferSchema.inferField("60") == IntegerType)
+    assert(InferSchema.inferField("3.5") == DoubleType)
+    assert(InferSchema.inferField("test") == StringType)
+
+  }
+
+}

--- a/src/test/scala/com/databricks/spark/csv/util/InferSchemaSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/InferSchemaSuite.scala
@@ -5,15 +5,19 @@ import org.scalatest.FunSuite
 
 class InferSchemaSuite extends FunSuite {
 
-  test("String fields types are inferred correctly"){
-
-    assert(InferSchema.inferField("") == NullType)
-    assert(InferSchema.inferField(null) == NullType)
-    assert(InferSchema.inferField("100000000000") == LongType)
-    assert(InferSchema.inferField("60") == IntegerType)
-    assert(InferSchema.inferField("3.5") == DoubleType)
-    assert(InferSchema.inferField("test") == StringType)
-
+  test("String fields types are inferred correctly from null types"){
+    assert(InferSchema.inferField(NullType, "") == NullType)
+    assert(InferSchema.inferField(NullType, null) == NullType)
+    assert(InferSchema.inferField(NullType, "100000000000") == LongType)
+    assert(InferSchema.inferField(NullType, "60") == IntegerType)
+    assert(InferSchema.inferField(NullType, "3.5") == DoubleType)
+    assert(InferSchema.inferField(NullType, "test") == StringType)
   }
 
+  test("String fields types are inferred correctly from other types"){
+    assert(InferSchema.inferField(LongType, "1.0") == DoubleType)
+    assert(InferSchema.inferField(LongType, "test") == StringType)
+    assert(InferSchema.inferField(IntegerType, "1.0") == DoubleType)
+    assert(InferSchema.inferField(DoubleType, null) == DoubleType)
+  }
 }


### PR DESCRIPTION
This resolves #60 , the schema is inferred in a similar way to how the JSON schema is inferred.

The public api has not changed other than adding the inferSchema option, e.g.:
    
    csvFile(carsFile, inferSchema = true)

    OPTIONS (path "path", inferSchema "true")

I have pulled the tokenizing code into a common method as the schema has to be inferred on the tokenized data.

Currently this uses the entire dataset to discover the schema, I could also add on a sampling `samplingRatio` option as in the JSON schema inference?  