### PR TITLE
Integrate code coverage metrics using codecov.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,7 @@ jdk:
 sudo: false
 script:
   - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test test
+  - sbt -jvm-opts travis/jvmopts.test coverage test
   - sbt -jvm-opts travis/jvmopts.test scalastyle
+after_success:
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 A library for parsing and querying CSV data with Apache Spark, for Spark SQL and DataFrames.
 
 [![Build Status](https://travis-ci.org/databricks/spark-csv.svg?branch=master)](https://travis-ci.org/databricks/spark-csv)
+[![codecov.io](http://codecov.io/github/databricks/spark-csv/coverage.svg?branch=master)](http://codecov.io/github/databricks/spark-csv?branch=master)
 
 ## Requirements
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,3 +66,8 @@ sparkComponents += "sql"
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 
 libraryDependencies += "com.novocode" % "junit-interface" % "0.9" % "test"
+
+ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
+  if (scalaBinaryVersion.value == "2.10") false
+  else false
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -31,6 +31,8 @@ addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.3.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-pgp" % "0.8")
 
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.1.0")
+
 libraryDependencies += "org.ow2.asm"  % "asm" % "5.0.3"
 
 libraryDependencies += "org.ow2.asm"  % "asm-commons" % "5.0.3"


### PR DESCRIPTION
This PR is an attempt to integrate code coverage into our build using Scoverage and http://codecov.io.

If this works (fingers crossed), you should be able to view coverage metrics at https://codecov.io/github/databricks/spark-csv or in GitHub by using the Codecov Chrome plugin.