### PR TITLE
parsing options and serializing arrays

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,20 +12,9 @@ libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
 libraryDependencies += "com.univocity" % "univocity-parsers" % "1.5.1"
 
-libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
+libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % Provided
 
-libraryDependencies ++= Seq(
-  ("org.apache.spark" %% "spark-sql" % "1.4.0").
-//    exclude("org.mortbay.jetty", "servlet-api").
-    exclude("commons-beanutils", "commons-beanutils-core").
-    exclude("commons-collections", "commons-collections").
-    exclude("commons-logging", "commons-logging").
-    exclude("org.slf4j", "slf4j-api").
-    exclude("org.apache.hadoop", "hadoop-yarn-api").
-    exclude("org.apache.hadoop", "hadoop-yarn-common").
-    exclude("com.esotericsoftware.minlog", "minlog")
-)
-
+libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.4.0" % Provided
 
 resolvers ++= Seq(
   "Apache Staging" at "https://repository.apache.org/content/repositories/staging/",

--- a/build.sbt
+++ b/build.sbt
@@ -1,20 +1,31 @@
 name := "spark-csv"
 
-version := "1.1.0"
+version := "1.1.0-SNAPSHOT"
 
 organization := "com.databricks"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.10.4"
 
 parallelExecution in Test := false
-
-crossScalaVersions := Seq("2.10.4", "2.11.6")
 
 libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
 
 libraryDependencies += "com.univocity" % "univocity-parsers" % "1.5.1"
 
 libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
+
+libraryDependencies ++= Seq(
+  ("org.apache.spark" %% "spark-sql" % "1.4.0").
+//    exclude("org.mortbay.jetty", "servlet-api").
+    exclude("commons-beanutils", "commons-beanutils-core").
+    exclude("commons-collections", "commons-collections").
+    exclude("commons-logging", "commons-logging").
+    exclude("org.slf4j", "slf4j-api").
+    exclude("org.apache.hadoop", "hadoop-yarn-api").
+    exclude("org.apache.hadoop", "hadoop-yarn-common").
+    exclude("com.esotericsoftware.minlog", "minlog")
+)
+
 
 resolvers ++= Seq(
   "Apache Staging" at "https://repository.apache.org/content/repositories/staging/",
@@ -23,45 +34,6 @@ resolvers ++= Seq(
 )
 
 publishMavenStyle := true
-
-spAppendScalaVersion := true
-
-spIncludeMaven := true
-
-publishTo := {
-  val nexus = "https://oss.sonatype.org/"
-  if (version.value.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
-
-pomExtra := (
-  <url>https://github.com/databricks/spark-csv</url>
-  <licenses>
-    <license>
-      <name>Apache License, Verision 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>git@github.com:databricks/spark-csv.git</url>
-    <connection>scm:git:git@github.com:databricks/spark-csv.git</connection>
-  </scm>
-  <developers>
-    <developer>
-      <id>falaki</id>
-      <name>Hossein Falaki</name>
-      <url>http://www.falaki.net</url>
-    </developer>
-  </developers>)
-
-spName := "databricks/spark-csv"
-
-sparkVersion := "1.4.0"
-
-sparkComponents += "sql"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
 

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -16,9 +16,9 @@
 package com.databricks.spark.csv
 
 
-import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.types.StructType
-import com.databricks.spark.csv.util.{ParserLibs, ParseModes}
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import com.databricks.spark.csv.util.{ParseModes, ParserLibs}
 
 /**
  * A collection of static functions for working with CSV files in Spark SQL
@@ -26,15 +26,13 @@ import com.databricks.spark.csv.util.{ParserLibs, ParseModes}
 class CsvParser {
 
   private var useHeader: Boolean = false
-  private var delimiter: Character = ','
-  private var quote: Character = '"'
-  private var escape: Character = null
+  private var csvParsingOpts: CSVParsingOpts = CSVParsingOpts()
+  private var lineParsingOpts: LineParsingOpts = LineParsingOpts()
+  private var numberParsingOpts: NumberParsingOpts = NumberParsingOpts()
+  private var stringParsingOpts: StringParsingOpts = StringParsingOpts()
   private var schema: StructType = null
   private var parseMode: String = ParseModes.DEFAULT
-  private var ignoreLeadingWhiteSpace: Boolean = false
-  private var ignoreTrailingWhiteSpace: Boolean = false
   private var parserLib: String = ParserLibs.DEFAULT
-
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -42,12 +40,12 @@ class CsvParser {
   }
 
   def withDelimiter(delimiter: Character): CsvParser = {
-    this.delimiter = delimiter
+    this.csvParsingOpts.delimiter = delimiter
     this
   }
 
   def withQuoteChar(quote: Character): CsvParser = {
-    this.quote = quote
+    this.csvParsingOpts.quoteChar = quote
     this
   }
 
@@ -62,22 +60,42 @@ class CsvParser {
   }
 
   def withEscape(escapeChar: Character): CsvParser = {
-    this.escape = escapeChar
+    this.csvParsingOpts.escapeChar = escapeChar
     this
   }
 
   def withIgnoreLeadingWhiteSpace(ignore: Boolean): CsvParser = {
-    this.ignoreLeadingWhiteSpace = ignore
+    this.csvParsingOpts.ignoreLeadingWhitespace = ignore
     this
   }
 
   def withIgnoreTrailingWhiteSpace(ignore: Boolean): CsvParser = {
-    this.ignoreTrailingWhiteSpace = ignore
+    this.csvParsingOpts.ignoreTrailingWhitespace = ignore
     this
   }
 
   def withParserLib(parserLib: String): CsvParser = {
     this.parserLib = parserLib
+    this
+  }
+
+  def withCsvParsingOpts(csvParsingOpts: CSVParsingOpts) = {
+    this.csvParsingOpts = csvParsingOpts
+    this
+  }
+
+  def withLineParsingOpts(lineParsingOpts: LineParsingOpts) = {
+    this.lineParsingOpts = lineParsingOpts
+    this
+  }
+
+  def withNumberParsingOpts(numberParsingOpts: NumberParsingOpts) = {
+    this.numberParsingOpts = numberParsingOpts
+    this
+  }
+
+  def withStringParsingOpts(stringParsingOpts: StringParsingOpts) = {
+    this.stringParsingOpts = stringParsingOpts
     this
   }
 
@@ -87,14 +105,13 @@ class CsvParser {
     val relation: CsvRelation = CsvRelation(
       path,
       useHeader,
-      delimiter,
-      quote,
-      escape,
+      csvParsingOpts,
       parseMode,
       parserLib,
-      ignoreLeadingWhiteSpace,
-      ignoreTrailingWhiteSpace,
-      schema)(sqlContext)
+      schema,
+      lineParsingOpts,
+      numberParsingOpts,
+      stringParsingOpts)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -106,6 +106,15 @@ class CsvParser {
     this
   }
 
+  def withOpts(optMap: Map[String, String]) = {
+    this.stringParsingOpts = StringParsingOpts(optMap)
+    this.lineParsingOpts = LineParsingOpts(optMap)
+    this.realNumberParsingOpts = RealNumberParsingOpts(optMap)
+    this.intNumberParsingOpts = IntNumberParsingOpts(optMap)
+    this.csvParsingOpts = CSVParsingOpts(optMap)
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -28,7 +28,8 @@ class CsvParser {
   private var useHeader: Boolean = false
   private var csvParsingOpts: CSVParsingOpts = CSVParsingOpts()
   private var lineParsingOpts: LineParsingOpts = LineParsingOpts()
-  private var numberParsingOpts: NumberParsingOpts = NumberParsingOpts()
+  private var realNumberParsingOpts: RealNumberParsingOpts = RealNumberParsingOpts()
+  private var intNumberParsingOpts: IntNumberParsingOpts = IntNumberParsingOpts()
   private var stringParsingOpts: StringParsingOpts = StringParsingOpts()
   private var schema: StructType = null
   private var parseMode: String = ParseModes.DEFAULT
@@ -89,10 +90,16 @@ class CsvParser {
     this
   }
 
-  def withNumberParsingOpts(numberParsingOpts: NumberParsingOpts) = {
-    this.numberParsingOpts = numberParsingOpts
+  def withRealNumberParsingOpts(numberParsingOpts: RealNumberParsingOpts) = {
+    this.realNumberParsingOpts = numberParsingOpts
     this
   }
+
+  def withIntNumberParsingOpts(numberParsingOpts: IntNumberParsingOpts) = {
+    this.intNumberParsingOpts = numberParsingOpts
+    this
+  }
+
 
   def withStringParsingOpts(stringParsingOpts: StringParsingOpts) = {
     this.stringParsingOpts = stringParsingOpts
@@ -110,7 +117,8 @@ class CsvParser {
       parserLib,
       schema,
       lineParsingOpts,
-      numberParsingOpts,
+      realNumberParsingOpts,
+      intNumberParsingOpts,
       stringParsingOpts)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -64,7 +64,7 @@ case class CsvRelation protected[spark] (
 
   // By making this a lazy val we keep the RDD around, amortizing the cost of locating splits.
   def buildScan = {
-    val baseRDD = sqlContext.sparkContext.textFile(location)
+    val baseRDD = sqlContext.sparkContext.textFile(location, csvParsingOpts.numParts)
 
     val fieldNames = schema.fieldNames
 

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -16,9 +16,10 @@
 package com.databricks.spark.csv
 
 import org.apache.hadoop.fs.Path
-import org.apache.spark.sql.{DataFrame, SaveMode, SQLContext}
+
 import org.apache.spark.sql.sources._
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
 import com.databricks.spark.csv.util.{ParserLibs, TypeCast}
 
 /**
@@ -102,16 +103,17 @@ class DefaultSource
       throw new Exception("Ignore white space flag can be true or false")
     }
 
+    val csvParsingOpts = CSVParsingOpts(delimiter = delimiter,
+      quoteChar = quoteChar,
+      escapeChar = escapeChar,
+      ignoreLeadingWhitespace = ignoreLeadingWhiteSpaceFlag,
+      ignoreTrailingWhitespace = ignoreTrailingWhiteSpaceFlag)
 
     CsvRelation(path,
       headerFlag,
-      delimiter,
-      quoteChar,
-      escapeChar,
+      csvParsingOpts,
       parseMode,
       parserLib,
-      ignoreLeadingWhiteSpaceFlag,
-      ignoreTrailingWhiteSpaceFlag,
       schema)(sqlContext)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
+++ b/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
@@ -84,4 +84,5 @@ case class CSVParsingOpts(var delimiter: Character = ',',
                           var quoteChar: Character = '"',
                           var escapeChar: Character = '\\',
                           var ignoreLeadingWhitespace: Boolean = true,
-                          var ignoreTrailingWhitespace: Boolean = true)
+                          var ignoreTrailingWhitespace: Boolean = true,
+                          var numParts: Int = 0)

--- a/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
+++ b/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
@@ -1,0 +1,87 @@
+// scalastyle:off
+/*
+ * Copyright 2015 Ayasdi Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// scalastyle:on
+
+package com.databricks.spark.csv
+
+import scala.collection.immutable.HashSet
+
+/**
+ * Action to take when malformed lines are found in a CSV File
+ */
+object LineExceptionPolicy {
+
+  sealed trait EnumVal
+
+  /**
+   * ignore the malformed line and continue
+   */
+  case object Ignore extends EnumVal
+
+  /**
+   * stop parsing and abort
+   */
+  case object Abort extends EnumVal
+
+  /**
+   * if fields are missing in a line, fill in the blanks
+   */
+  case object Fill extends EnumVal
+
+}
+
+/**
+ * Options to control parsing of numbers
+ * @param emptyStringReplace replace empty string with this string
+ * @param nanStrings these strings are NaNs
+ * @param nanValue this is the value to use for NaN
+ * @param enable make this false to stop attempting to parse numbers i.e. treat them as strings
+ */
+case class NumberParsingOpts(var emptyStringReplace: String = "NaN",
+                             var nanStrings: Set[String] = HashSet("NaN", "NULL", "N/A"),
+                             var nanValue: Double = Double.NaN,
+                             var enable: Boolean = true)
+
+/**
+  * Options to control parsing of strings
+  * @param emptyStringReplace replace empty string with this string
+  */
+case class StringParsingOpts(var emptyStringReplace: String = "",
+                             var nullStrings: Set[String] = HashSet("NULL", "null", "n/a", "N/A"))
+
+/**
+ * options to handle exceptions while parsing a line
+ * @param badLinePolicy abort, ignore line or fill with nulls when a bad line is encountered
+ * @param fillValue if line exception policy is to fill in the blanks, use this value to fill
+ */
+case class LineParsingOpts(var badLinePolicy: LineExceptionPolicy.EnumVal = LineExceptionPolicy.Fill,
+                           var fillValue: String = "")
+
+/**
+ * CSV parsing options
+ * @param quoteChar fields containing delimiters, other special chars are quoted using this character
+ *                  e.g. "this is a comma ,"
+ * @param escapeChar if a quote character appears in a field, it is escaped using this
+ *                   e.g. "this is a quote \""
+ * @param ignoreLeadingWhitespace ignore white space before a field
+ * @param ignoreTrailingWhitespace ignore white space after a field
+ */
+case class CSVParsingOpts(var delimiter: Character = ',',
+                          var quoteChar: Character = '"',
+                          var escapeChar: Character = '\\',
+                          var ignoreLeadingWhitespace: Boolean = true,
+                          var ignoreTrailingWhitespace: Boolean = true)

--- a/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
+++ b/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
@@ -44,24 +44,37 @@ object LineExceptionPolicy {
 
 }
 
-/**
- * Options to control parsing of numbers
- * @param emptyStringReplace replace empty string with this string
- * @param nanStrings these strings are NaNs
- * @param nanValue this is the value to use for NaN
- * @param enable make this false to stop attempting to parse numbers i.e. treat them as strings
- */
-case class NumberParsingOpts(var emptyStringReplace: String = "NaN",
-                             var nanStrings: Set[String] = HashSet("NaN", "NULL", "N/A"),
-                             var nanValue: Double = Double.NaN,
-                             var enable: Boolean = true)
+object ParsingOptions {
+  val defaultNullStrings = HashSet("", "NULL", "N/A", "null", "n/a")
+  val defaultNaNStrings = HashSet("NaN", "nan")
+  val defaultInfPosString = HashSet("+Inf", "Inf", "Infinity", "+Infinity", "inf", "+inf")
+  val defaultInfNegString = HashSet("-Inf", "-inf", "-Infinity")
+}
 
 /**
-  * Options to control parsing of strings
-  * @param emptyStringReplace replace empty string with this string
-  */
+ * Options to control parsing of real numbers e.g. the types Float and Double
+ * @param nanStrings these strings are NaNs
+ * @param enable make this false to stop attempting to parse numbers i.e. treat them as strings
+ */
+case class RealNumberParsingOpts(var nanStrings: Set[String] =  ParsingOptions.defaultNaNStrings,
+                                 var infPosStrings: Set[String] = ParsingOptions.defaultInfPosString,
+                                 var infNegStrings: Set[String] = ParsingOptions.defaultInfNegString,
+                                 var nullStrings: Set[String] = ParsingOptions.defaultNullStrings,
+                                 var enable: Boolean = true)
+
+/**
+ * Options to control parsing of integral numbers e.g. the types Int and Long
+ * @param enable make this false to stop attempting to parse numbers i.e. treat them as strings
+ */
+case class IntNumberParsingOpts(var nullStrings: Set[String] = ParsingOptions.defaultNullStrings,
+                                var enable: Boolean = true)
+
+/**
+ * Options to control parsing of strings
+ * @param emptyStringReplace replace empty string with this string
+ */
 case class StringParsingOpts(var emptyStringReplace: String = "",
-                             var nullStrings: Set[String] = HashSet("NULL", "null", "n/a", "N/A"))
+                             var nullStrings: Set[String] =  ParsingOptions.defaultNullStrings)
 
 /**
  * options to handle exceptions while parsing a line
@@ -79,6 +92,7 @@ case class LineParsingOpts(var badLinePolicy: LineExceptionPolicy.EnumVal = Line
  *                   e.g. "this is a quote \""
  * @param ignoreLeadingWhitespace ignore white space before a field
  * @param ignoreTrailingWhitespace ignore white space after a field
+ * @param numParts number of partitions to use in sc.textFile()
  */
 case class CSVParsingOpts(var delimiter: Character = ',',
                           var quoteChar: Character = '"',

--- a/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
+++ b/src/main/scala/com/databricks/spark/csv/ParsingOptions.scala
@@ -56,11 +56,12 @@ object ParsingOptions {
  * @param nanStrings these strings are NaNs
  * @param enable make this false to stop attempting to parse numbers i.e. treat them as strings
  */
-case class RealNumberParsingOpts(var nanStrings: Set[String] =  ParsingOptions.defaultNaNStrings,
-                                 var infPosStrings: Set[String] = ParsingOptions.defaultInfPosString,
-                                 var infNegStrings: Set[String] = ParsingOptions.defaultInfNegString,
-                                 var nullStrings: Set[String] = ParsingOptions.defaultNullStrings,
-                                 var enable: Boolean = true)
+case class RealNumberParsingOpts(
+    var nanStrings: Set[String] = ParsingOptions.defaultNaNStrings,
+    var infPosStrings: Set[String] = ParsingOptions.defaultInfPosString,
+    var infNegStrings: Set[String] = ParsingOptions.defaultInfNegString,
+    var nullStrings: Set[String] = ParsingOptions.defaultNullStrings,
+    var enable: Boolean = true)
 
 /**
  * Options to control parsing of integral numbers e.g. the types Int and Long
@@ -81,13 +82,14 @@ case class StringParsingOpts(var emptyStringReplace: String = "",
  * @param badLinePolicy abort, ignore line or fill with nulls when a bad line is encountered
  * @param fillValue if line exception policy is to fill in the blanks, use this value to fill
  */
-case class LineParsingOpts(var badLinePolicy: LineExceptionPolicy.EnumVal = LineExceptionPolicy.Fill,
-                           var fillValue: String = "")
+case class LineParsingOpts(
+   var badLinePolicy: LineExceptionPolicy.EnumVal = LineExceptionPolicy.Fill,
+   var fillValue: String = "")
 
 /**
  * CSV parsing options
- * @param quoteChar fields containing delimiters, other special chars are quoted using this character
- *                  e.g. "this is a comma ,"
+ * @param quoteChar fields containing delimiters, other special chars are quoted using this
+ *                  character e.g. "this is a comma ,"
  * @param escapeChar if a quote character appears in a field, it is escaped using this
  *                   e.g. "this is a quote \""
  * @param ignoreLeadingWhitespace ignore white space before a field

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -123,8 +123,8 @@ package object csv {
 
       val generateHeader = parameters.getOrElse("header", "false").toBoolean
 
-      val isSparse: Array[Boolean] =  dataFrame.columns.flatMap { colName: String =>
-        if (sparseColInfo.contains(colName)) {
+      val isSparse: Array[Boolean] = dataFrame.columns.flatMap { colName: String =>
+        if (sparseColInfo != null && sparseColInfo.contains(colName)) {
           Array.fill(sparseColInfo(colName).size)(true)
         } else {
           Array(false)

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -15,6 +15,9 @@
  */
 package com.databricks.spark
 
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
 import org.apache.commons.csv.CSVFormat
 import org.apache.hadoop.io.compress.CompressionCodec
 
@@ -76,7 +79,9 @@ package object csv {
      * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
      */
     def saveAsCsvFile(path: String, parameters: Map[String, String] = Map(),
-                      compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
+                      compressionCodec: Class[_ <: CompressionCodec] = null,
+                      sparseColInfo: mutable.Map[String, mutable.Map[String, Int]] = null): Unit = {
+
       // TODO(hossein): For nested types, we may want to perform special work
       val delimiter = parameters.getOrElse("delimiter", ",")
       val delimiterChar = if (delimiter.length == 1) {
@@ -117,8 +122,32 @@ package object csv {
       }
 
       val generateHeader = parameters.getOrElse("header", "false").toBoolean
+
+      val isSparse: Array[Boolean] =  dataFrame.columns.flatMap { colName: String =>
+        if (sparseColInfo.contains(colName)) {
+          Array.fill(sparseColInfo(colName).size)(true)
+        } else {
+          Array(false)
+        }
+      }
+
+      def makeHeader : String = {
+        val hs = dataFrame.columns.flatMap { colName: String =>
+          if (sparseColInfo.contains(colName)) {
+            require(sparseColInfo.contains(colName))
+            sparseColInfo(colName).toSeq.sortBy(_._2).map(_._1)
+          } else {
+            Seq(colName)
+          }
+        }
+        csvFormat.format(hs : _*)
+      }
+
       val header = if (generateHeader) {
-        csvFormat.format(dataFrame.columns.map(_.asInstanceOf[AnyRef]):_*)
+        if (sparseColInfo == null)
+          csvFormat.format(dataFrame.columns.map(_.asInstanceOf[AnyRef]): _*)
+        else
+          makeHeader
       } else {
         "" // There is no need to generate header in this case
       }
@@ -144,7 +173,17 @@ package object csv {
 
           override def next: String = {
             if(!iter.isEmpty) {
-              val row = csvFormat.format(iter.next.toSeq.map(_.asInstanceOf[AnyRef]):_*)
+              def makeCsvRow(inFields: Seq[Any]) : String = {
+                val fields = inFields.flatMap { f =>
+                  if(isSparse(inFields.indexOf(f))) {
+                    f.asInstanceOf[ArrayBuffer[Any]]
+                  } else {
+                    ArrayBuffer(f)
+                  }
+                }
+                csvFormat.format(fields.map(_.asInstanceOf[AnyRef]): _*)
+              }
+              val row = makeCsvRow(iter.next.toSeq)
               if (firstRow) {
                 firstRow = false
                 header + csvFormat.getRecordSeparator() + row

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -35,16 +35,17 @@ package object csv {
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
                 ignoreTrailingWhiteSpace: Boolean = false) = {
+      val csvParsingOpts = CSVParsingOpts(delimiter = delimiter,
+        quoteChar = quote,
+        escapeChar = escape,
+        ignoreLeadingWhitespace = ignoreLeadingWhiteSpace,
+        ignoreTrailingWhitespace = ignoreTrailingWhiteSpace)
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
-        delimiter = delimiter,
-        quote = quote,
-        escape = escape,
+        csvParsingOpts = csvParsingOpts,
         parseMode = mode,
-        parserLib = parserLib,
-        ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
-        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
+        parserLib = parserLib)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
@@ -53,16 +54,18 @@ package object csv {
                 parserLib: String = "COMMONS",
                 ignoreLeadingWhiteSpace: Boolean = false,
                 ignoreTrailingWhiteSpace: Boolean = false) = {
+      val csvParsingOpts = CSVParsingOpts(delimiter = '\t',
+        quoteChar = '"',
+        escapeChar = '\\',
+        ignoreLeadingWhitespace = ignoreLeadingWhiteSpace,
+        ignoreTrailingWhitespace = ignoreTrailingWhiteSpace)
+
       val csvRelation = CsvRelation(
         location = filePath,
         useHeader = useHeader,
-        delimiter = '\t',
-        quote = '"',
-        escape = '\\',
+        csvParsingOpts = csvParsingOpts,
         parseMode = "PERMISSIVE",
-        parserLib = parserLib,
-        ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
-        ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace)(sqlContext)
+        parserLib = parserLib)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -120,6 +120,8 @@ package object csv {
         "" // There is no need to generate header in this case
       }
 
+      val headerPerPart = parameters.getOrElse("headerPerPart", "true").toBoolean
+
       val strRDD = dataFrame.rdd.mapPartitionsWithIndex { case (index, iter) =>
         val csvFormatBase = CSVFormat.DEFAULT
           .withDelimiter(delimiterChar)
@@ -133,7 +135,7 @@ package object csv {
         }
 
         new Iterator[String] {
-          var firstRow: Boolean = generateHeader
+          var firstRow: Boolean = if(headerPerPart) generateHeader else generateHeader && index == 0
 
           override def hasNext = iter.hasNext || firstRow
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -144,10 +144,11 @@ package object csv {
       }
 
       val header = if (generateHeader) {
-        if (sparseColInfo == null)
+        if (sparseColInfo == null) {
           csvFormat.format(dataFrame.columns.map(_.asInstanceOf[AnyRef]): _*)
-        else
+        } else {
           makeHeader
+        }
       } else {
         "" // There is no need to generate header in this case
       }

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -36,8 +36,8 @@ package object csv {
                 escape: Character = null,
                 mode: String = "PERMISSIVE",
                 parserLib: String = "COMMONS",
-                ignoreLeadingWhiteSpace: Boolean = false,
-                ignoreTrailingWhiteSpace: Boolean = false) = {
+                ignoreLeadingWhiteSpace: Boolean = true,
+                ignoreTrailingWhiteSpace: Boolean = true) = {
       val csvParsingOpts = CSVParsingOpts(delimiter = delimiter,
         quoteChar = quote,
         escapeChar = escape,

--- a/src/test/resources/cars-alternative.csv
+++ b/src/test/resources/cars-alternative.csv
@@ -1,5 +1,5 @@
 year|make|model|comment
-'2012'|'Tesla'|'S'| 'No comment'
+ '2012' |'Tesla'|'S'| 'No comment'
 
-1997|Ford|E350|'Go get one now they are going fast'
-2015|Chevy|Volt
+ 1997|Ford|E350|'Go get one now they are going fast'
+2015 |Chevy|Volt

--- a/src/test/resources/numbers.csv
+++ b/src/test/resources/numbers.csv
@@ -1,0 +1,11 @@
+double, float, int, long
+1.0, 1.0, 1, 1
+ , , ,
+NaN, NaN, 3, 3
+NULL, null, N/A, n/a
+Inf, Inf, 5, 5
+-Inff, -Inff, 6, 6
+Infinity, Infinity, 7, 7
+
+
+

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -240,7 +240,7 @@ class CsvFastSuite extends FunSuite {
     val copyFilePath = tempEmptyDir + "cars-copy.csv"
 
     val cars = TestSQLContext.csvFile(carsFile, parserLib = "univocity")
-    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true"))
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "headerPerPart" -> "false"))
 
     val carsCopy = TestSQLContext.csvFile(copyFilePath + "/")
 
@@ -255,7 +255,7 @@ class CsvFastSuite extends FunSuite {
     val copyFilePath = tempEmptyDir + "cars-copy.csv"
 
     val cars = TestSQLContext.csvFile(carsFile, parserLib = "univocity")
-    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true"), classOf[GzipCodec])
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "headerPerPart" -> "false"), classOf[GzipCodec])
 
     val carsCopy = TestSQLContext.csvFile(copyFilePath + "/")
 
@@ -270,7 +270,7 @@ class CsvFastSuite extends FunSuite {
     val copyFilePath = tempEmptyDir + "cars-copy.csv"
 
     val cars = TestSQLContext.csvFile(carsFile, parserLib = "univocity")
-    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "\""))
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true",  "headerPerPart" -> "false", "quote" -> "\""))
 
     val carsCopy = TestSQLContext.csvFile(copyFilePath + "/", parserLib = "univocity")
 
@@ -285,7 +285,7 @@ class CsvFastSuite extends FunSuite {
     val copyFilePath = tempEmptyDir + "cars-copy.csv"
 
     val cars = TestSQLContext.csvFile(carsFile)
-    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "!"))
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true",  "headerPerPart" -> "false", "quote" -> "!"))
 
     val carsCopy = TestSQLContext.csvFile(copyFilePath + "/", quote = '!', parserLib = "univocity")
 
@@ -300,7 +300,7 @@ class CsvFastSuite extends FunSuite {
     val copyFilePath = tempEmptyDir + "escape-copy.csv"
 
     val escape = TestSQLContext.csvFile(escapeFile, escape='|', quote='"')
-    escape.saveAsCsvFile(copyFilePath, Map("header" -> "true", "quote" -> "\""))
+    escape.saveAsCsvFile(copyFilePath, Map("header" -> "true",  "headerPerPart" -> "false", "quote" -> "\""))
 
     val escapeCopy = TestSQLContext.csvFile(copyFilePath + "/", parserLib = "univocity")
 

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -145,7 +145,7 @@ class CsvSuite extends FunSuite {
       .collect()
 
     assert(results.slice(0, numCars).toSeq.map(_(0).asInstanceOf[String]) ==
-      Seq("'2012'", "1997", "2015"))
+      Seq(" '2012' ", " 1997", "2015 "))
   }
 
   test("DDL test with alternative delimiter and quote") {

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -120,6 +120,20 @@ class CsvSuite extends FunSuite {
     assert(results.size === numCars)
   }
 
+  test("DSL test with alternative delimiter and quote using simple options API") {
+    val optMap = Map("csvParsingOpts.quote" -> "'",
+      "csvParsingOpts.delimiter" -> "|"
+    )
+
+    val results = new CsvParser().withOpts(optMap)
+      .withUseHeader(true)
+      .csvFile(TestSQLContext, carsAltFile)
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars)
+  }
+
   test("DSL test with alternative delimiter and quote using sparkContext.csvFile") {
     val results =
       TestSQLContext.csvFile(carsAltFile, useHeader = true, delimiter = '|', quote = '\'')

--- a/src/test/scala/com/databricks/spark/csv/OptionsSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/OptionsSuite.scala
@@ -1,0 +1,89 @@
+// scalastyle:off
+/*
+ * Copyright 2015 Ayasdi Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+// scalastyle:on
+package com.databricks.spark.csv
+
+import scala.collection.immutable.HashSet
+
+import org.scalatest.FunSuite
+
+class OptionsSuite extends FunSuite {
+  test("csv opts") {
+    val optMap = Map("csvParsingOpts.delimiter" -> "|",
+      "csvParsingOpts.quote" -> "[",
+      "csvParsingOpts.ignoreLeadingSpace" -> "false",
+      "csvParsingOpts.ignoreTrailingSpace" -> "true",
+      "csvParsingOpts.escape" -> ":",
+      "csvParsingOpts.numParts" -> "5")
+    println(optMap)
+    val opts = CSVParsingOpts(optMap)
+
+    assert(opts.delimiter === '|')
+    assert(opts.escapeChar === ':')
+    assert(opts.ignoreLeadingWhitespace === false)
+    assert(opts.ignoreTrailingWhitespace === true)
+    assert(opts.numParts === 5)
+    assert(opts.quoteChar === '[')
+  }
+
+  test("line opts") {
+    val optMap = Map("lineParsingOpts.badLinePolicy" -> "abort",
+      "lineParsingOpts.fillValue" -> "duh")
+    println(optMap)
+    val opts = LineParsingOpts(optMap)
+
+    assert(opts.fillValue === "duh")
+    assert(opts.badLinePolicy === LineExceptionPolicy.Abort)
+  }
+
+  test("string opts") {
+    val optMap = Map("stringParsingOpts.nulls" -> "abcd,efg",
+      "stringParsingOpts.emptyStringReplace" -> "<empty>")
+    println(optMap)
+    val opts = StringParsingOpts(optMap)
+
+    assert(opts.nullStrings === HashSet("abcd", "efg"))
+    assert(opts.emptyStringReplace === "<empty>")
+  }
+
+  test("int opts") {
+    val optMap = Map("intNumParsingOpts.nulls" -> "abcd,efg",
+      "intNumParsingOpts.enable" -> "false")
+    println(optMap)
+    val opts = IntNumberParsingOpts(optMap)
+
+    assert(opts.nullStrings === HashSet("abcd", "efg"))
+    assert(opts.enable === false)
+  }
+
+  test("real opts") {
+    val optMap = Map("realNumParsingOpts.nulls" -> "abcd,efg",
+      "realNumParsingOpts.enable" -> "false",
+      "realNumParsingOpts.nans" -> "NaN,nan",
+      "realNumParsingOpts.infs" -> "iinnff,IINNFF",
+      "realNumParsingOpts.-infs" -> "minusInf")
+    println(optMap)
+    val opts = RealNumberParsingOpts(optMap)
+
+    assert(opts.nullStrings === HashSet("abcd", "efg"))
+    assert(opts.nanStrings === HashSet("NaN", "nan"))
+    assert(opts.infPosStrings === HashSet("iinnff", "IINNFF"))
+    assert(opts.infNegStrings === HashSet("minusInf"))
+    assert(opts.enable === false)
+  }
+
+}

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -19,7 +19,7 @@ import java.math.BigDecimal
 
 import org.scalatest.FunSuite
 
-import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.types.{FloatType, DoubleType, DecimalType}
 
 class TypeCastSuite extends FunSuite {
 
@@ -30,6 +30,19 @@ class TypeCastSuite extends FunSuite {
 
     stringValues.zip(decimalValues).foreach { case (strVal, decimalVal) =>
       assert(TypeCast.castTo(strVal, decimalType) === new BigDecimal(decimalVal.toString))
+    }
+  }
+
+  test("Can parse special") {
+    val strValues = Seq("NaN", "Infinity", "-Infinity")
+    val doubleChecks: Seq[Double => Boolean] = Seq(x => x.isNaN, x => x.isPosInfinity, x => x.isNegInfinity)
+    val floatChecks: Seq[Float => Boolean] = Seq(x => x.isNaN, x => x.isPosInfinity, x => x.isNegInfinity)
+
+    strValues.zip(doubleChecks).foreach { case (strVal, checker) =>
+      assert(checker(TypeCast.castTo(strVal, DoubleType).asInstanceOf[Double]))
+    }
+    strValues.zip(floatChecks).foreach { case (strVal, checker) =>
+      assert(checker(TypeCast.castTo(strVal, FloatType).asInstanceOf[Float]))
     }
   }
 


### PR DESCRIPTION
several parsing options are added. they are organized in classes because there are many of them. a "text" based API to configure options is provided.

another feature is the ability to serialize a column of arrays. the array is "unnested" and column names to use are supplied by user. this is useful for writing out csv after doing transforms on the data that "expand" the number of columns e.g. one hot encode a category. this can be improved later. e.g. sparse vector from mllib can replace the array.