### PR TITLE
Adding csvRdd method which allows parsing csvs from a preexisting rdd.

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -115,7 +115,6 @@ class CsvParser extends Serializable {
       ignoreLeadingWhiteSpace,
       ignoreTrailingWhiteSpace,
       schema,
-      charset,
       inferSchema)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
@@ -135,7 +134,6 @@ class CsvParser extends Serializable {
       ignoreLeadingWhiteSpace,
       ignoreTrailingWhiteSpace,
       schema,
-      charset,
       inferSchema)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
 

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -16,6 +16,7 @@
 package com.databricks.spark.csv
 
 
+import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, SQLContext}
 import org.apache.spark.sql.types.StructType
 import com.databricks.spark.csv.util.{ParserLibs, ParseModes, TextFile}
@@ -23,7 +24,7 @@ import com.databricks.spark.csv.util.{ParserLibs, ParseModes, TextFile}
 /**
  * A collection of static functions for working with CSV files in Spark SQL
  */
-class CsvParser {
+class CsvParser extends Serializable {
 
   private var useHeader: Boolean = false
   private var delimiter: Character = ','
@@ -102,7 +103,8 @@ class CsvParser {
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
     val relation: CsvRelation = CsvRelation(
-      path,
+      () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
+      Some(path),
       useHeader,
       delimiter,
       quote,
@@ -118,5 +120,24 @@ class CsvParser {
     sqlContext.baseRelationToDataFrame(relation)
   }
 
-}
+  def csvRdd(sqlContext: SQLContext, csvRDD: RDD[String]): DataFrame ={
 
+    val relation: CsvRelation = CsvRelation(
+      () => csvRDD,
+      None,
+      useHeader,
+      delimiter,
+      quote,
+      escape,
+      comment,
+      parseMode,
+      parserLib,
+      ignoreLeadingWhiteSpace,
+      ignoreTrailingWhiteSpace,
+      schema,
+      charset,
+      inferSchema)(sqlContext)
+    sqlContext.baseRelationToDataFrame(relation)
+
+  }
+}

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -44,7 +44,6 @@ case class CsvRelation protected[spark] (
     ignoreLeadingWhiteSpace: Boolean,
     ignoreTrailingWhiteSpace: Boolean,
     userSchema: StructType = null,
-    charset: String = TextFile.DEFAULT_CHARSET.name(),
     inferCsvSchema: Boolean)(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with InsertableRelation {
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -32,7 +32,8 @@ import com.databricks.spark.csv.util._
 import com.databricks.spark.sql.readers._
 
 case class CsvRelation protected[spark] (
-    location: String,
+    baseRDD: () => RDD[String],
+    location: Option[String],
     useHeader: Boolean,
     delimiter: Char,
     quote: Char,
@@ -71,10 +72,8 @@ case class CsvRelation protected[spark] (
 
   def tokenRdd(header: Array[String]): RDD[Array[String]] = {
 
-    val baseRDD = TextFile.withCharset(sqlContext.sparkContext, location, charset)
-
     if(ParserLibs.isUnivocityLib(parserLib)) {
-      univocityParseCSV(baseRDD, header)
+      univocityParseCSV(baseRDD(), header)
     } else {
       val csvFormat = CSVFormat.DEFAULT
         .withDelimiter(delimiter)
@@ -87,7 +86,7 @@ case class CsvRelation protected[spark] (
       // If header is set, make sure firstLine is materialized before sending to executors.
       val filterLine = if (useHeader) firstLine else null
 
-      baseRDD.mapPartitions { iter =>
+      baseRDD().mapPartitions { iter =>
         // When using header, any input line that equals firstLine is assumed to be header
         val csvIter = if (useHeader) {
           iter.filter(_ != filterLine)
@@ -167,16 +166,15 @@ case class CsvRelation protected[spark] (
    * Returns the first line of the first non-empty file in path
    */
   private lazy val firstLine = {
-    val csv = TextFile.withCharset(sqlContext.sparkContext, location, charset)
     if (comment == null) {
-      csv.first()
+      baseRDD().first()
     } else {
-      csv.take(MAX_COMMENT_LINES_IN_HEADER)
+      baseRDD().take(MAX_COMMENT_LINES_IN_HEADER)
         .find(! _.startsWith(comment.toString))
         .getOrElse(sys.error(s"No uncommented header line in " +
           s"first $MAX_COMMENT_LINES_IN_HEADER lines"))
     }
-   }
+  }
 
   private def univocityParseCSV(
      file: RDD[String],
@@ -220,7 +218,13 @@ case class CsvRelation protected[spark] (
 
   // The function below was borrowed from JSONRelation
   override def insert(data: DataFrame, overwrite: Boolean) = {
-    val filesystemPath = new Path(location)
+
+    val filesystemPath = location match {
+      case Some(p) => new Path(p)
+      case None =>
+        throw new IOException(s"Cannot INSERT into table with no path defined")
+    }
+
     val fs = filesystemPath.getFileSystem(sqlContext.sparkContext.hadoopConfiguration)
 
     if (overwrite) {
@@ -233,7 +237,7 @@ case class CsvRelation protected[spark] (
               + s" to INSERT OVERWRITE a CSV table:\n${e.toString}")
       }
       // Write the data. We assume that schema isn't changed, and we won't update it.
-      data.saveAsCsvFile(location, Map("delimiter" -> delimiter.toString))
+      data.saveAsCsvFile(filesystemPath.toString, Map("delimiter" -> delimiter.toString))
     } else {
       sys.error("CSV tables only support INSERT OVERWRITE for now.")
     }

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -123,7 +123,9 @@ class DefaultSource
       throw new Exception("Infer schema flag can be true or false")
     }
 
-    CsvRelation(path,
+    CsvRelation(
+      () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
+      Some(path),
       headerFlag,
       delimiter,
       quoteChar,

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -136,7 +136,6 @@ class DefaultSource
       ignoreLeadingWhiteSpaceFlag,
       ignoreTrailingWhiteSpaceFlag,
       schema,
-      charset,
       inferSchemaFlag)(sqlContext)
   }
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -17,9 +17,8 @@ package com.databricks.spark
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.hadoop.io.compress.CompressionCodec
-import org.apache.spark.rdd.RDD
 
-import org.apache.spark.sql.{DataFrameReader, DataFrame, SQLContext}
+import org.apache.spark.sql.{DataFrame, SQLContext}
 import com.databricks.spark.csv.util.TextFile
 
 package object csv {

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -51,7 +51,6 @@ package object csv {
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
-        charset = charset,
         inferCsvSchema = inferSchema)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
@@ -75,7 +74,6 @@ package object csv {
         parserLib = parserLib,
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
-        charset = charset,
         inferCsvSchema = inferSchema)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
@@ -173,5 +171,4 @@ package object csv {
       }
     }
   }
-
 }

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -17,8 +17,9 @@ package com.databricks.spark
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.hadoop.io.compress.CompressionCodec
+import org.apache.spark.rdd.RDD
 
-import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.apache.spark.sql.{DataFrameReader, DataFrame, SQLContext}
 import com.databricks.spark.csv.util.TextFile
 
 package object csv {
@@ -26,7 +27,7 @@ package object csv {
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.
    */
-  implicit class CsvContext(sqlContext: SQLContext) {
+  implicit class CsvContext(sqlContext: SQLContext) extends Serializable{
     def csvFile(filePath: String,
                 useHeader: Boolean = true,
                 delimiter: Char = ',',
@@ -40,7 +41,8 @@ package object csv {
                 charset: String = TextFile.DEFAULT_CHARSET.name(),
                 inferSchema: Boolean = false) = {
       val csvRelation = CsvRelation(
-        location = filePath,
+        () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
+        location = Some(filePath),
         useHeader = useHeader,
         delimiter = delimiter,
         quote = quote,
@@ -63,7 +65,8 @@ package object csv {
                 charset: String = TextFile.DEFAULT_CHARSET.name(),
                 inferSchema: Boolean = false) = {
       val csvRelation = CsvRelation(
-        location = filePath,
+        () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
+        location = Some(filePath),
         useHeader = useHeader,
         delimiter = '\t',
         quote = '"',
@@ -171,4 +174,5 @@ package object csv {
       }
     }
   }
+
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -492,4 +492,13 @@ class CsvFastSuite extends FunSuite {
     }
     assert(exception.getMessage.contains("Cannot INSERT into table with no path defined"))
   }
+
+  test("DSL tsv test") {
+    val results = TestSQLContext
+      .tsvFile(carsTsvFile, parserLib = "UNIVOCITY")
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars)
+  }
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -456,5 +456,40 @@ class CsvFastSuite extends FunSuite {
     assert(results.toSeq.map(_.toSeq) == expected)
   }
 
+  test("DSL load csv from rdd") {
 
+    val csvRdd = TestSQLContext.sparkContext.parallelize(Seq("age,height", "20,1.8", "16,1.7"))
+    val df = new CsvParser()
+      .withUseHeader(true)
+      .withParserLib("UNIVOCITY")
+      .csvRdd(TestSQLContext, csvRdd)
+      .collect()
+
+    assert(df(0).toSeq == Seq("20", "1.8"))
+    assert(df(1).toSeq == Seq("16", "1.7"))
+
+  }
+
+  test("Inserting into csvRdd should throw exception"){
+
+    val csvRdd = TestSQLContext.sparkContext.parallelize(Seq("age,height", "20,1.8", "16,1.7"))
+    val sampleData = TestSQLContext.sparkContext.parallelize(Seq("age,height", "20,1.8", "16,1.7"))
+
+    val df = new CsvParser()
+      .withUseHeader(true)
+      .withParserLib("UNIVOCITY")
+      .csvRdd(TestSQLContext, csvRdd)
+    val sampleDf = new CsvParser()
+      .withUseHeader(true)
+      .withParserLib("UNIVOCITY")
+      .csvRdd(TestSQLContext, sampleData)
+
+    df.registerTempTable("csvRdd")
+    sampleDf.registerTempTable("sampleDf")
+
+    val exception = intercept[java.io.IOException] {
+      sql("INSERT OVERWRITE TABLE csvRdd select * from sampleDf")
+    }
+    assert(exception.getMessage.contains("Cannot INSERT into table with no path defined"))
+  }
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -441,4 +441,30 @@ class CsvSuite extends FunSuite {
     assert(results.toSeq.map(_.toSeq) == expected)
   }
 
+  test("DSL load csv from rdd") {
+
+    val csvRdd = TestSQLContext.sparkContext.parallelize(Seq("age,height", "20,1.8", "16,1.7"))
+    val df = new CsvParser().withUseHeader(true).csvRdd(TestSQLContext, csvRdd).collect()
+
+    assert(df(0).toSeq == Seq("20", "1.8"))
+    assert(df(1).toSeq == Seq("16", "1.7"))
+
+  }
+
+  test("Inserting into csvRdd should throw exception"){
+
+    val csvRdd = TestSQLContext.sparkContext.parallelize(Seq("age,height", "20,1.8", "16,1.7"))
+    val sampleData = TestSQLContext.sparkContext.parallelize(Seq("age,height", "20,1.8", "16,1.7"))
+
+    val df = new CsvParser().withUseHeader(true).csvRdd(TestSQLContext, csvRdd)
+    val sampleDf = new CsvParser().withUseHeader(true).csvRdd(TestSQLContext, sampleData)
+
+    df.registerTempTable("csvRdd")
+    sampleDf.registerTempTable("sampleDf")
+
+    val exception = intercept[java.io.IOException] {
+      sql("INSERT OVERWRITE TABLE csvRdd select * from sampleDf")
+    }
+    assert(exception.getMessage.contains("Cannot INSERT into table with no path defined"))
+  }
 }

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -467,4 +467,13 @@ class CsvSuite extends FunSuite {
     }
     assert(exception.getMessage.contains("Cannot INSERT into table with no path defined"))
   }
+
+  test("DSL tsv test") {
+    val results = TestSQLContext
+      .tsvFile(carsTsvFile)
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars)
+  }
 }


### PR DESCRIPTION
Closes #91 and closes #62 . This allows an existing string RDD to be loaded as a csv with:
 `new CsvParser().csvRdd(rdd)`

I've pulled out the path from the CsvRelation so that it is instead passed through as an RDD. This is passed through as a function so that it's is recreated on every operation, which is also how the json relation works.

I've had to make CsvParser and CsvContext serializable - this is because the anonymous functions are declared there. The anonymous function could be moved into the CsvRelation constructor?
