### PR TITLE
Printing content of records when failing or dropping

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -103,10 +103,10 @@ case class CsvRelation protected[spark] (
     tokenRdd(schemaFields.map(_.name)).flatMap{ tokens =>
 
       if (dropMalformed && schemaFields.length != tokens.size) {
-        logger.warn(s"Dropping malformed line: $tokens")
+        logger.warn(s"Dropping malformed line: ${tokens.mkString(",")}")
         None
       } else if (failFast && schemaFields.length != tokens.size) {
-        throw new RuntimeException(s"Malformed line in FAILFAST mode: $tokens")
+        throw new RuntimeException(s"Malformed line in FAILFAST mode: ${tokens.mkString(",")}")
       } else {
         var index: Int = 0
         val rowArray = new Array[Any](schemaFields.length)
@@ -179,7 +179,7 @@ case class CsvRelation protected[spark] (
      file: RDD[String],
      header: Seq[String]): RDD[Array[String]] = {
     // If header is set, make sure firstLine is materialized before sending to executors.
-    val filterLine = if (useHeader) firstLine else null
+    val filterLine = if(useHeader) firstLine else null
     val dataLines = if(useHeader) file.filter(_ != filterLine) else file
     val rows = dataLines.mapPartitionsWithIndex({
       case (split, iter) => {

--- a/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvFastSuite.scala
@@ -143,7 +143,7 @@ class CsvFastSuite extends FunSuite {
         .collect()
     }
 
-    assert(exception.getMessage.contains("Malformed line in FAILFAST mode"))
+    assert(exception.getMessage.contains("Malformed line in FAILFAST mode: 2015,Chevy,Volt"))
   }
 
 

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -137,7 +137,7 @@ class CsvSuite extends FunSuite {
         .collect()
     }
 
-    assert(exception.getMessage.contains("Malformed line in FAILFAST mode"))
+    assert(exception.getMessage.contains("Malformed line in FAILFAST mode: 2015,Chevy,Volt"))
   }
 
 


### PR DESCRIPTION
Constructing printable string when logging content of malformed lines.

closes #131 