### PR TITLE
Test against Spark 1.3.0 and 1.5.0-rc2 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
       env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
   - sbt ++$TRAVIS_SCALA_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION coverage test
-  - sbt ++$TRAVIS_SCALA_VERSION scalastyle
+  # Disable scalastyle for tests until # https://github.com/scalastyle/scalastyle/issues/156 is fixed:
+  # - sbt ++$TRAVIS_SCALA_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,34 @@
 language: scala
-scala:
-  - 2.10.4
-jdk:
-  - openjdk7
-  - openjdk6
 sudo: false
+cache:
+  directories:
+    - $HOME/.ivy2
+matrix:
+  include:
+    # Spark 1.3.0
+    - jdk: openjdk6
+      scala: 2.10.4
+      env: TEST_SPARK_VERSION="1.3.0"
+    - jdk: openjdk6
+      scala: 2.11.6
+      env: TEST_SPARK_VERSION="1.3.0"
+    # Spark 1.4.0
+    - jdk: openjdk6
+      scala: 2.11.6
+      env: TEST_SPARK_VERSION="1.4.0"
+    - jdk: openjdk7
+      scala: 2.11.6
+      env: TEST_SPARK_VERSION="1.4.0"
+    # Spark 1.5.0
+    # TOOD: after 1.5.0 is released, update this to use the released version
+    - jdk: openjdk7
+      scala: 2.10.4
+      env: TEST_SPARK_VERSION="1.5.0-rc2"
+    - jdk: openjdk7
+      scala: 2.11.6
+      env: TEST_SPARK_VERSION="1.5.0-rc2"
 script:
-  - sbt -jvm-opts travis/jvmopts.compile compile
-  - sbt -jvm-opts travis/jvmopts.test coverage test
-  - sbt -jvm-opts travis/jvmopts.test scalastyle
+  - sbt ++$TRAVIS_SCALA_VERSION -Dspark.testVersion=$TEST_SPARK_VERSION coverage test
+  - sbt ++$TRAVIS_SCALA_VERSION scalastyle
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ spName := "databricks/spark-csv"
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 
-sparkVersion := "1.4.0"
+sparkVersion := "1.3.0"
 
 val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,20 +6,38 @@ organization := "com.databricks"
 
 scalaVersion := "2.11.6"
 
-parallelExecution in Test := false
+spName := "databricks/spark-csv"
 
 crossScalaVersions := Seq("2.10.4", "2.11.6")
 
-libraryDependencies += "org.apache.commons" % "commons-csv" % "1.1"
+sparkVersion := "1.4.0"
 
-libraryDependencies += "com.univocity" % "univocity-parsers" % "1.5.1"
+val testSparkVersion = settingKey[String]("The version of Spark to test against.")
 
-libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.5" % "provided"
+testSparkVersion := sys.props.get("spark.testVersion").getOrElse(sparkVersion.value)
 
 resolvers ++= Seq(
   "Apache Staging" at "https://repository.apache.org/content/repositories/staging/",
   "Typesafe" at "http://repo.typesafe.com/typesafe/releases",
   "Local Maven Repository" at "file://"+Path.userHome.absolutePath+"/.m2/repository"
+)
+
+// TODO: remove once Spark 1.5.0 is released.
+resolvers += "Spark 1.5.0 RC2 Staging" at "https://repository.apache.org/content/repositories/orgapachespark-1141"
+
+sparkComponents := Seq("core", "sql")
+
+libraryDependencies ++= Seq(
+  "org.apache.commons" % "commons-csv" % "1.1",
+  "com.univocity" % "univocity-parsers" % "1.5.1",
+  "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
+  "org.scalatest" %% "scalatest" % "2.2.1" % "test",
+  "com.novocode" % "junit-interface" % "0.9" % "test"
+)
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % testSparkVersion.value % "test" force(),
+  "org.apache.spark" %% "spark-sql" % testSparkVersion.value % "test" force()
 )
 
 publishMavenStyle := true
@@ -57,17 +75,9 @@ pomExtra := (
     </developer>
   </developers>)
 
-spName := "databricks/spark-csv"
-
-sparkVersion := "1.4.0"
-
-sparkComponents += "sql"
-
-libraryDependencies += "org.scalatest" %% "scalatest" % "2.2.1" % "test"
-
-libraryDependencies += "com.novocode" % "junit-interface" % "0.9" % "test"
+parallelExecution in Test := false
 
 ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := {
   if (scalaBinaryVersion.value == "2.10") false
-  else false
+  else true
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -14,4 +14,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-sbt.version=0.13.6
+sbt.version=0.13.9

--- a/src/test/java/com/databricks/spark/csv/JavaCsvSuite.java
+++ b/src/test/java/com/databricks/spark/csv/JavaCsvSuite.java
@@ -2,15 +2,14 @@ package com.databricks.spark.csv;
 
 import java.io.File;
 import java.util.HashMap;
-import java.util.Random;
 
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import org.apache.spark.SparkContext;
 import org.apache.spark.sql.*;
-import org.apache.spark.sql.test.TestSQLContext$;
 
 public class JavaCsvSuite {
   private transient SQLContext sqlContext;
@@ -22,12 +21,12 @@ public class JavaCsvSuite {
 
   @Before
   public void setUp() {
-    // Trigger static initializer of TestData
-    sqlContext = TestSQLContext$.MODULE$;
+    sqlContext = new SQLContext(new SparkContext("local[2]", "JavaCsvSuite"));
   }
 
   @After
   public void tearDown() {
+    sqlContext.sparkContext().stop();
     sqlContext = null;
   }
 

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -120,6 +120,8 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DDL test parsing decimal type") {
+    assume(org.apache.spark.SPARK_VERSION.take(3) > "1.3",
+      "DecimalType is broken on Spark 1.3.x")
     sqlContext.sql(
       s"""
          |CREATE TEMPORARY TABLE carsTable

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -17,10 +17,10 @@ package com.databricks.spark.csv.util
 
 import java.nio.charset.UnsupportedCharsetException
 
-import org.apache.spark.sql.test.TestSQLContext
-import org.scalatest.FunSuite
+import org.apache.spark.SparkContext
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
-class TextFileSuite extends FunSuite {
+class TextFileSuite extends FunSuite with BeforeAndAfterAll {
   val carsFile = "src/test/resources/cars.csv"
   val carsFile8859 = "src/test/resources/cars_iso-8859-1.csv"
   val numLines = 6
@@ -29,32 +29,47 @@ class TextFileSuite extends FunSuite {
   val utf8 = "utf-8"
   val iso88591 = "iso-8859-1"
 
+  private var sparkContext: SparkContext = _
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    sparkContext = new SparkContext("local[2]", "TextFileSuite")
+  }
+
+  override def afterAll(): Unit = {
+    try {
+      sparkContext.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
   test("read utf-8 encoded file") {
-    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile, utf8)
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
   }
 
   test("read utf-8 encoded file using charset alias") {
-    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile, "utf8")
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile, "utf8")
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
   }
 
   test("read iso-8859-1 encoded file") {
-    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile8859, iso88591)
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, iso88591)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == smallThorn) == numColumns)
   }
 
   test("read iso-8859-1 encoded file using charset alias") {
-    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile8859, "8859_1")
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, "8859_1")
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == smallThorn) == numColumns)
   }
 
   test("read iso-8859-1 encoded file with invalid charset") {
-    val baseRDD = TextFile.withCharset(TestSQLContext.sparkContext, carsFile8859, utf8)
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, utf8)
     assert(baseRDD.count() === numLines)
     // file loads but since it's not encoded in utf-8, non-ascii characters are not decoded
     // correctly.
@@ -63,7 +78,7 @@ class TextFileSuite extends FunSuite {
 
   test("unsupported charset") {
     val exception = intercept[UnsupportedCharsetException] {
-      TextFile.withCharset(TestSQLContext.sparkContext, carsFile, "frylock").count()
+      TextFile.withCharset(sparkContext, carsFile, "frylock").count()
     }
     assert(exception.getMessage.contains("frylock"))
   }


### PR DESCRIPTION
This patch adds Spark 1.3.0 and 1.5.0-rc2 to our Travis build matrix. I removed the use of TestSQLContext since that class has been removed in Spark 1.5.

This patch also fixes #128, a binary incompatibility which broke schema inference on Spark 1.3.x.