### PR TITLE
the data was not expected if delimiter is '|'

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -45,7 +45,7 @@ class CsvParser extends Serializable {
   }
 
   def withDelimiter(delimiter: Character): CsvParser = {
-    this.delimiter = delimiter
+    this.delimiter = if (delimiter == '|') '\u0003' else delimiter
     this
   }
 

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -51,7 +51,8 @@ class DefaultSource
       parameters: Map[String, String],
       schema: StructType): CsvRelation = {
     val path = checkPath(parameters)
-    val delimiter = TypeCast.toChar(parameters.getOrElse("delimiter", ","))
+    val delimiter_ = TypeCast.toChar(parameters.getOrElse("delimiter", ","))
+    val delimiter  = if (delimiter_ == '|') '\u0003' else delimiter_
 
     val quote = parameters.getOrElse("quote", "\"")
     val quoteChar = if (quote.length == 1) {


### PR DESCRIPTION
I fixed two issues here:

1) if CSV data was delimited by '|', then the data was separated by each character.
2) if the column header has non-alphabet and not-digit, such as '(' , space etc,  save as ORC on Spark was failed.

so, I just:
1) if delimiter is '|', then changed to '\u0003' internally.
2) normalize the column header to keep only alphabet and digit, replace other characters with '_'

