### PR TITLE
TypeCast double and float according to your Locale if default cast fails

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -16,7 +16,8 @@
 package com.databricks.spark.csv.util
 
 import java.math.BigDecimal
-import java.sql.{Timestamp, Date}
+import java.sql.{Date, Timestamp}
+import java.text.NumberFormat
 import java.util.Locale
 
 import org.apache.spark.sql.types._
@@ -52,9 +53,9 @@ object TypeCast {
         case _: IntegerType => datum.toInt
         case _: LongType => datum.toLong
         case _: FloatType => Try(datum.toFloat)
-          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
+          .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
         case _: DoubleType => Try(datum.toDouble)
-          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
+          .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
         case _: BooleanType => datum.toBoolean
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
         // TODO(hossein): would be good to support other common timestamp formats
@@ -77,7 +78,7 @@ object TypeCast {
   private[csv] def toChar(str: String): Char = {
     if (str.charAt(0) == '\\') {
       str.charAt(1)
-       match {
+      match {
         case 't' => '\t'
         case 'r' => '\r'
         case 'b' => '\b'

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -52,9 +52,9 @@ object TypeCast {
         case _: IntegerType => datum.toInt
         case _: LongType => datum.toLong
         case _: FloatType => Try(datum.toFloat)
-          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
+          .getOrElse(java.text.NumberFormat.getInstance(locale).parse(datum).floatValue())
         case _: DoubleType => Try(datum.toDouble)
-          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
+          .getOrElse(java.text.NumberFormat.getInstance(locale).parse(datum).doubleValue())
         case _: BooleanType => datum.toBoolean
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
         // TODO(hossein): would be good to support other common timestamp formats

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -52,9 +52,9 @@ object TypeCast {
         case _: IntegerType => datum.toInt
         case _: LongType => datum.toLong
         case _: FloatType => Try(datum.toFloat)
-          .getOrElse(java.text.NumberFormat.getInstance(locale).parse(datum).floatValue())
+          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
         case _: DoubleType => Try(datum.toDouble)
-          .getOrElse(java.text.NumberFormat.getInstance(locale).parse(datum).doubleValue())
+          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
         case _: BooleanType => datum.toBoolean
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
         // TODO(hossein): would be good to support other common timestamp formats

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -17,8 +17,11 @@ package com.databricks.spark.csv.util
 
 import java.math.BigDecimal
 import java.sql.{Timestamp, Date}
+import java.util.Locale
 
 import org.apache.spark.sql.types._
+
+import scala.util.Try
 
 /**
  * Utility functions for type casting
@@ -48,8 +51,10 @@ object TypeCast {
         case _: ShortType => datum.toShort
         case _: IntegerType => datum.toInt
         case _: LongType => datum.toLong
-        case _: FloatType => datum.toFloat
-        case _: DoubleType => datum.toDouble
+        case _: FloatType => Try(datum.toFloat)
+          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
+        case _: DoubleType => Try(datum.toDouble)
+          .getOrElse(java.text.NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
         case _: BooleanType => datum.toBoolean
         case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
         // TODO(hossein): would be good to support other common timestamp formats

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -80,7 +80,9 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("10", IntegerType) == 10)
     assert(TypeCast.castTo("10", LongType) == 10)
     assert(TypeCast.castTo("1.00", FloatType) == 1.0)
+    assert(TypeCast.castTo("1,00", DoubleType) == 1.0)
     assert(TypeCast.castTo("1.00", DoubleType) == 1.0)
+    assert(TypeCast.castTo("1,00", DoubleType) == 1.0)
     assert(TypeCast.castTo("true", BooleanType) == true)
     val timestamp = "2015-01-01 00:00:00"
     assert(TypeCast.castTo(timestamp, TimestampType) == Timestamp.valueOf(timestamp))

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -17,6 +17,7 @@ package com.databricks.spark.csv.util
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}
+import java.util.Locale
 
 import org.scalatest.FunSuite
 
@@ -80,9 +81,9 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("10", IntegerType) == 10)
     assert(TypeCast.castTo("10", LongType) == 10)
     assert(TypeCast.castTo("1.00", FloatType) == 1.0)
-    assert(TypeCast.castTo("1,00", DoubleType) == 1.0)
+    assert(TypeCast.castTo("1,00", DoubleType, locale = Locale.FRANCE) == 1.0)
     assert(TypeCast.castTo("1.00", DoubleType) == 1.0)
-    assert(TypeCast.castTo("1,00", DoubleType) == 1.0)
+    assert(TypeCast.castTo("1,00", DoubleType, locale = Locale.FRANCE) == 1.0)
     assert(TypeCast.castTo("true", BooleanType) == true)
     val timestamp = "2015-01-01 00:00:00"
     assert(TypeCast.castTo(timestamp, TimestampType) == Timestamp.valueOf(timestamp))

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -81,12 +81,17 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("10", IntegerType) == 10)
     assert(TypeCast.castTo("10", LongType) == 10)
     assert(TypeCast.castTo("1.00", FloatType) == 1.0)
-    assert(TypeCast.castTo("1,00", FloatType, locale = Locale.FRANCE) == 1.0)
     assert(TypeCast.castTo("1.00", DoubleType) == 1.0)
-    assert(TypeCast.castTo("1,00", DoubleType, locale = Locale.FRANCE) == 1.0)
     assert(TypeCast.castTo("true", BooleanType) == true)
     val timestamp = "2015-01-01 00:00:00"
     assert(TypeCast.castTo(timestamp, TimestampType) == Timestamp.valueOf(timestamp))
     assert(TypeCast.castTo("2015-01-01", DateType) == Date.valueOf("2015-01-01"))
+  }
+
+  test("Float and Double Types are cast correctly with Locale") {
+    val locale : Locale = new Locale("fr", "FR")
+    Locale.setDefault(locale)
+    assert(TypeCast.castTo("1,00", FloatType) == 1.0)
+    assert(TypeCast.castTo("1,00", DoubleType) == 1.0)
   }
 }

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -81,7 +81,7 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("10", IntegerType) == 10)
     assert(TypeCast.castTo("10", LongType) == 10)
     assert(TypeCast.castTo("1.00", FloatType) == 1.0)
-    assert(TypeCast.castTo("1,00", DoubleType, locale = Locale.FRANCE) == 1.0)
+    assert(TypeCast.castTo("1,00", FloatType, locale = Locale.FRANCE) == 1.0)
     assert(TypeCast.castTo("1.00", DoubleType) == 1.0)
     assert(TypeCast.castTo("1,00", DoubleType, locale = Locale.FRANCE) == 1.0)
     assert(TypeCast.castTo("true", BooleanType) == true)


### PR DESCRIPTION
In some regions decimal types have comma instead dot.  Currently spark-csv cast to Double or Float using .toDouble or toFloat scala functions. 

If we have double or float types with comma (and the delimiter is another character) we could try to use the java.text.NumberFormat and get the default Locale. 
