### PR TITLE
Adding a short name for spark-csv pacakge

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,1 +1,1 @@
-com.databricks.spark.csv.DefaultSource
+com.databricks.spark.csv.DefaultSource15

--- a/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -1,0 +1,1 @@
+com.databricks.spark.csv.DefaultSource

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -36,11 +36,6 @@ class DefaultSource
   }
 
   /**
-   * Short alias for spark-csv data source.
-   */
-  override def shortName(): String = "csv"
-
-  /**
    * Creates a new relation for data store in CSV given parameters.
    * Parameters have to include 'path' and optionally 'delimiter', 'quote', and 'header'
    */

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -28,8 +28,7 @@ import com.databricks.spark.csv.util.{ParserLibs, TextFile, TypeCast}
 class DefaultSource
   extends RelationProvider
   with SchemaRelationProvider
-  with CreatableRelationProvider
-  with DataSourceRegister {
+  with CreatableRelationProvider {
 
   private def checkPath(parameters: Map[String, String]): String = {
     parameters.getOrElse("path", sys.error("'path' must be specified for CSV data."))

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -26,11 +26,19 @@ import com.databricks.spark.csv.util.{ParserLibs, TextFile, TypeCast}
  * JDBC server).
  */
 class DefaultSource
-  extends RelationProvider with SchemaRelationProvider with CreatableRelationProvider {
+  extends RelationProvider
+  with SchemaRelationProvider
+  with CreatableRelationProvider
+  with DataSourceRegister {
 
   private def checkPath(parameters: Map[String, String]): String = {
     parameters.getOrElse("path", sys.error("'path' must be specified for CSV data."))
   }
+
+  /**
+   * Short alias for spark-csv data source.
+   */
+  override def shortName(): String = "csv"
 
   /**
    * Creates a new relation for data store in CSV given parameters.

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource15.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource15.scala
@@ -15,9 +15,12 @@
  */
 package com.databricks.spark.csv
 
-/* Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility. 
- * Since the class is loaded through META-INF/services we can decouple the two to have 
- * Spark 1.5 byte-code loaded lazily. 
+import org.apache.spark.sql.sources.DataSourceRegister
+
+/* Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility.
+ * Since the class is loaded through META-INF/services we can decouple the two to have
+ * Spark 1.5 byte-code loaded lazily.
+ *
  * This trick is adapted from spark elasticsearch-hadoop data source:
  * <https://github.com/elastic/elasticsearch-hadoop>
  */
@@ -28,4 +31,3 @@ class DefaultSource15 extends DefaultSource with DataSourceRegister {
    */
   override def shortName(): String = "csv"
 }
-

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource15.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource15.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.csv
+
+/* Extension of DefaultSource (which is Spark 1.3 and 1.4 compatible) for Spark 1.5 compatibility. 
+ * Since the class is loaded through META-INF/services we can decouple the two to have 
+ * Spark 1.5 byte-code loaded lazily. 
+ * This trick is adapted from spark elasticsearch-hadoop data source:
+ * <https://github.com/elastic/elasticsearch-hadoop>
+ */
++class DefaultSource15 extends DefaultSource with DataSourceRegister {
+
+  /**
+   * Short alias for spark-csv data source.
+   */
+  override def shortName(): String = "csv"
+}
+

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource15.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource15.scala
@@ -21,7 +21,7 @@ package com.databricks.spark.csv
  * This trick is adapted from spark elasticsearch-hadoop data source:
  * <https://github.com/elastic/elasticsearch-hadoop>
  */
-+class DefaultSource15 extends DefaultSource with DataSourceRegister {
+class DefaultSource15 extends DefaultSource with DataSourceRegister {
 
   /**
    * Short alias for spark-csv data source.

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -99,7 +99,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DDL test with alias name") {
-    assume(org.apache.spark.SPARK_VERSION.take(3) > "1.4",
+    assume(org.apache.spark.SPARK_VERSION.take(3) >= "1.5",
       "Datasource alias feature was added in Spark 1.5")
 
     sqlContext.sql(

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -98,6 +98,17 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
     assert(sqlContext.sql("SELECT year FROM carsTable").collect().size === numCars)
   }
 
+  test("DDL test with alias name") {
+    sqlContext.sql(
+      s"""
+         |CREATE TEMPORARY TABLE carsTsvTable
+         |USING csv
+         |OPTIONS (path "$carsTsvFile", header "true", delimiter "\t", parserLib "$parserLib")
+      """.stripMargin.replaceAll("\n", " "))
+
+    assert(sqlContext.sql("SELECT year FROM carsTable").collect().size === numCars)
+  }
+
   test("DDL test with charset") {
     // scalastyle:off
     sqlContext.sql(

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -99,6 +99,9 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DDL test with alias name") {
+    assume(org.apache.spark.SPARK_VERSION.take(3) > "1.4",
+      "Datasource alias feature was added in Spark 1.5")
+
     sqlContext.sql(
       s"""
          |CREATE TEMPORARY TABLE carsTsvTable


### PR DESCRIPTION
Users can now use spark-csv with following simpler query:

```
CREATE TEMPORARY TABLE myTable 
USING csv OPTIONS (path "/tmp/data", header "true")
```
No need to specify "com.databricks.spark.csv" as data source name

closes Issue #159 
