### PR TITLE
Nullable quote character

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -36,7 +36,7 @@ case class CsvRelation protected[spark] (
     location: Option[String],
     useHeader: Boolean,
     delimiter: Char,
-    quote: Char,
+    quote: Character,
     escape: Character,
     comment: Character,
     parseMode: String,
@@ -143,7 +143,8 @@ case class CsvRelation protected[spark] (
       val firstRow = if (ParserLibs.isUnivocityLib(parserLib)) {
         val escapeVal = if (escape == null) '\\' else escape.charValue()
         val commentChar: Char = if (comment == null) '\0' else comment
-        new LineCsvReader(fieldSep = delimiter, quote = quote, escape = escapeVal,
+        val quoteChar: Char = if (quote == null) '\0' else quote
+        new LineCsvReader(fieldSep = delimiter, quote = quoteChar, escape = escapeVal,
           commentMarker = commentChar).parseLine(firstLine)
       } else {
         val csvFormat = CSVFormat.DEFAULT
@@ -194,10 +195,11 @@ case class CsvRelation protected[spark] (
       case (split, iter) => {
         val escapeVal = if (escape == null) '\\' else escape.charValue()
         val commentChar: Char = if (comment == null) '\0' else comment
+        val quoteChar: Char = if (quote == null) '\0' else quote
 
         new BulkCsvReader(iter, split,
           headers = header, fieldSep = delimiter,
-          quote = quote, escape = escapeVal, commentMarker = commentChar)
+          quote = quoteChar, escape = escapeVal, commentMarker = commentChar)
       }
     }, true)
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -144,7 +144,10 @@ case class CsvRelation protected[spark] (
         val escapeVal = if (escape == null) '\\' else escape.charValue()
         val commentChar: Char = if (comment == null) '\0' else comment
         val quoteChar: Char = if (quote == null) '\0' else quote
-        new LineCsvReader(fieldSep = delimiter, quote = quoteChar, escape = escapeVal,
+        new LineCsvReader(
+          fieldSep = delimiter,
+          quote = quoteChar,
+          escape = escapeVal,
           commentMarker = commentChar).parseLine(firstLine)
       } else {
         val csvFormat = CSVFormat.DEFAULT

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -54,7 +54,9 @@ class DefaultSource
     val delimiter = TypeCast.toChar(parameters.getOrElse("delimiter", ","))
 
     val quote = parameters.getOrElse("quote", "\"")
-    val quoteChar = if (quote.length == 1) {
+    val quoteChar: Character = if (quote == null) {
+      null
+    } else if (quote.length == 1) {
       quote.charAt(0)
     } else {
       throw new Exception("Quotation cannot be more than one character.")

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -31,7 +31,7 @@ package object csv {
         filePath: String,
         useHeader: Boolean = true,
         delimiter: Char = ',',
-        quote: Character = '"',
+        quote: Char = '"',
         escape: Character = null,
         comment: Character = null,
         mode: String = "PERMISSIVE",

--- a/src/test/resources/cars-unbalanced-quotes.csv
+++ b/src/test/resources/cars-unbalanced-quotes.csv
@@ -1,0 +1,4 @@
+year,make,model,comment
+"2012,Tesla,S,No comment
+1997,Ford,E350,Go get one now they are going fast"
+"2015,"Chevy",Volt,

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -31,6 +31,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
   val carsFile8859 = "src/test/resources/cars_iso-8859-1.csv"
   val carsTsvFile = "src/test/resources/cars.tsv"
   val carsAltFile = "src/test/resources/cars-alternative.csv"
+  val carsUnbalancedQuotesFile = "src/test/resources/cars-unbalanced-quotes.csv"
   val nullNumbersFile = "src/test/resources/null-numbers.csv"
   val emptyFile = "src/test/resources/empty.csv"
   val ageFile = "src/test/resources/ages.csv"
@@ -201,6 +202,19 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       .withUseHeader(true)
       .withParserLib(parserLib)
       .csvFile(sqlContext, carsAltFile)
+      .select("year")
+      .collect()
+
+    assert(results.size === numCars)
+  }
+
+  test("DSL test with null quote character") {
+    val results = new CsvParser()
+      .withDelimiter(',')
+      .withQuoteChar(null)
+      .withUseHeader(true)
+      .withParserLib(parserLib)
+      .csvFile(sqlContext, carsUnbalancedQuotesFile)
       .select("year")
       .collect()
 


### PR DESCRIPTION
This pull request adds to spark-csv the functionality to provide a null for the quote character, in the event that no quoting is desired. This is necessary to interoperate with libraries such as Scalding which use unquoted formats by default.

Since the uniVocity parser uses a non-nullable char for the quoting character, a null byte is substituted in CsvRelation.scala if null was provided and uniVocity used, just as is already done for commentChar.

A test is also added using a comma-separated file with unbalanced double-quote characters.

Author: James Blau <james@tresata.com>

Closes #89 from tresata-opensource/feat-nullable-quotation-character.