### PR TITLE
Added defaultCsvFormat member to csv/package to use CSVFormat.DEFAULT…

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -75,7 +75,7 @@ case class CsvRelation protected[spark] (
     if (ParserLibs.isUnivocityLib(parserLib)) {
       univocityParseCSV(baseRDD(), header)
     } else {
-      val csvFormat = CSVFormat.DEFAULT
+      val csvFormat = defaultCsvFormat
         .withDelimiter(delimiter)
         .withQuote(quote)
         .withEscape(escape)
@@ -150,7 +150,7 @@ case class CsvRelation protected[spark] (
           escape = escapeVal,
           commentMarker = commentChar).parseLine(firstLine)
       } else {
-        val csvFormat = CSVFormat.DEFAULT
+        val csvFormat = defaultCsvFormat
           .withDelimiter(delimiter)
           .withQuote(quote)
           .withEscape(escape)

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -23,6 +23,8 @@ import com.databricks.spark.csv.util.TextFile
 
 package object csv {
 
+  val defaultCsvFormat = CSVFormat.DEFAULT.withRecordSeparator(System.lineSeparator())
+
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.
    */
@@ -118,7 +120,7 @@ package object csv {
 
       val nullValue = parameters.getOrElse("nullValue", "null")
 
-      val csvFormat = CSVFormat.DEFAULT
+      val csvFormat = defaultCsvFormat
         .withDelimiter(delimiterChar)
         .withQuote(quoteChar)
         .withEscape(escapeChar)
@@ -133,7 +135,7 @@ package object csv {
       }
 
       val strRDD = dataFrame.rdd.mapPartitionsWithIndex { case (index, iter) =>
-        val csvFormat = CSVFormat.DEFAULT
+        val csvFormat = defaultCsvFormat
           .withDelimiter(delimiterChar)
           .withQuote(quoteChar)
           .withEscape(escapeChar)

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -23,7 +23,7 @@ import com.databricks.spark.csv.util.TextFile
 
 package object csv {
 
-  val defaultCsvFormat = CSVFormat.DEFAULT.withRecordSeparator(System.lineSeparator())
+  val defaultCsvFormat = CSVFormat.DEFAULT.withRecordSeparator(System.getProperty("line.separator"))
 
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -23,7 +23,7 @@ import com.databricks.spark.csv.util.TextFile
 
 package object csv {
 
-  val defaultCsvFormat = CSVFormat.DEFAULT.withRecordSeparator(System.getProperty("line.separator"))
+  val defaultCsvFormat = CSVFormat.DEFAULT.withRecordSeparator(System.getProperty("line.separator", "\n"))
 
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -23,7 +23,8 @@ import com.databricks.spark.csv.util.TextFile
 
 package object csv {
 
-  val defaultCsvFormat = CSVFormat.DEFAULT.withRecordSeparator(System.getProperty("line.separator", "\n"))
+  val defaultCsvFormat =
+    CSVFormat.DEFAULT.withRecordSeparator(System.getProperty("line.separator", "\n"))
 
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.


### PR DESCRIPTION
Added defaultCsvFormat member to csv/package to use CSVFormat.DEFAULT with system line separator.

Spark-csv uses `org.apache.commons.csv.CSVFormat.DEFAULT` which uses line separator `\r\n`.  On UNIX systems, this results in the header line in output files to show up with a `^M` line ending.  I.e., the output looks like
```
Id      Name    City    Name_1  CustId  State^M
38228   Kathy   Callaway        Kathryn 38228   CA
45639   Ethel   Brownsville     Ethel   45639   AK
```
with the spurious `^M` on the header line. 

This fork addresses this issue by substituting a `defaultCsvFormat` member that sets the line separator to the system value.