### PR TITLE
Move compressionCodec to a string parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When reading files the API accepts several options:
 * `charset`: defaults to 'UTF-8' but can be set to other valid charset names
 * `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
-* `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`.
+* `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`. Defaults to no compression when a codec is not specified.
 
 The package also support saving simple (non-nested) DataFrame. When saving you can specify the delimiter and whether we should generate a header row for the table. See following examples for more details.
 
@@ -147,9 +147,6 @@ selectedData.write
     .option("codec", "org.apache.hadoop.io.compress.GzipCodec")
     .save("newcars.csv.gz")
 ```
-
-
-
 
 __Spark 1.3:__
 
@@ -250,9 +247,6 @@ df.select("year", "model").write()
     .save("newcars.csv");
 ```
 
-
-
-
 __Spark 1.3:__
 
 Automatically infer schema (data types), otherwise everything is assumed string:
@@ -315,8 +309,6 @@ df.select("year", "model").save("com.databricks.spark.csv", SaveMode.Overwrite,
                                 saveOptions);
 ```
 
-
-
 ### Python API
 
 __Spark 1.4+:__
@@ -362,8 +354,6 @@ df = sqlContext.read.format('com.databricks.spark.csv').options(header='true', i
 df.select('year', 'model').write.format('com.databricks.spark.csv').options(codec="org.apache.hadoop.io.compress.GzipCodec").save('newcars.csv')
 ```
 
-
-
 __Spark 1.3:__
 
 Automatically infer schema (data types), otherwise everything is assumed string:
@@ -400,8 +390,6 @@ sqlContext = SQLContext(sc)
 df = sqlContext.load(source="com.databricks.spark.csv", header = 'true', inferSchema = 'true', path = 'cars.csv')
 df.select('year', 'model').save('newcars.csv', 'com.databricks.spark.csv', codec="org.apache.hadoop.io.compress.GzipCodec")
 ```
-
-
 
 ### R API
 __Spark 1.4+:__

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ When reading files the API accepts several options:
 * `charset`: defaults to 'UTF-8' but can be set to other valid charset names
 * `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
+* `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`.
 
 The package also support saving simple (non-nested) DataFrame. When saving you can specify the delimiter and whether we should generate a header row for the table. See following examples for more details.
 
@@ -127,6 +128,27 @@ selectedData.write
     .option("header", "true")
     .save("newcars.csv")
 ```
+
+You can save with compressed output:
+```scala
+import org.apache.spark.sql.SQLContext
+
+val sqlContext = new SQLContext(sc)
+val df = sqlContext.read
+    .format("com.databricks.spark.csv")
+    .option("header", "true") // Use first line of all files as header
+    .option("inferSchema", "true") // Automatically infer data types
+    .load("cars.csv")
+
+val selectedData = df.select("year", "model")
+selectedData.write
+    .format("com.databricks.spark.csv")
+    .option("header", "true")
+    .option("codec", "org.apache.hadoop.io.compress.GzipCodec")
+    .save("newcars.csv.gz")
+```
+
+
 
 
 __Spark 1.3:__
@@ -210,6 +232,25 @@ df.select("year", "model").write()
     .save("newcars.csv");
 ```
 
+You can save with compressed output:
+```java
+import org.apache.spark.sql.SQLContext
+
+SQLContext sqlContext = new SQLContext(sc);
+DataFrame df = sqlContext.read()
+    .format("com.databricks.spark.csv")
+    .option("inferSchema", "true")
+    .option("header", "true")
+    .load("cars.csv");
+
+df.select("year", "model").write()
+    .format("com.databricks.spark.csv")
+    .option("header", "true")
+    .option("codec", "org.apache.hadoop.io.compress.GzipCodec")
+    .save("newcars.csv");
+```
+
+
 
 
 __Spark 1.3:__
@@ -236,7 +277,7 @@ import org.apache.spark.sql.types.*;
 
 SQLContext sqlContext = new SQLContext(sc);
 StructType customSchema = new StructType(
-    new StructField("year", IntegerType, true), 
+    new StructField("year", IntegerType, true),
     new StructField("make", StringType, true),
     new StructField("model", StringType, true),
     new StructField("comment", StringType, true),
@@ -250,6 +291,31 @@ options.put("path", "cars.csv");
 DataFrame df = sqlContext.load("com.databricks.spark.csv", customSchema, options);
 df.select("year", "model").save("newcars.csv", "com.databricks.spark.csv");
 ```
+
+You can save with compressed output:
+```java
+import org.apache.spark.sql.SQLContext;
+import org.apache.spark.sql.SaveMode;
+
+SQLContext sqlContext = new SQLContext(sc);
+
+HashMap<String, String> options = new HashMap<String, String>();
+options.put("header", "true");
+options.put("path", "cars.csv");
+options.put("inferSchema", "true");
+
+DataFrame df = sqlContext.load("com.databricks.spark.csv", options);
+
+HashMap<String, String> saveOptions = new HashMap<String, String>();
+saveOptions.put("header", "true");
+saveOptions.put("path", "newcars.csv");
+saveOptions.put("codec", "org.apache.hadoop.io.compress.GzipCodec");
+
+df.select("year", "model").save("com.databricks.spark.csv", SaveMode.Overwrite,
+                                saveOptions);
+```
+
+
 
 ### Python API
 
@@ -287,6 +353,16 @@ df.select('year', 'model').write \
     .save('newcars.csv')
 ```
 
+You can save with compressed output:
+```python
+from pyspark.sql import SQLContext
+sqlContext = SQLContext(sc)
+
+df = sqlContext.read.format('com.databricks.spark.csv').options(header='true', inferschema='true').load('cars.csv')
+df.select('year', 'model').write.format('com.databricks.spark.csv').options(codec="org.apache.hadoop.io.compress.GzipCodec").save('newcars.csv')
+```
+
+
 
 __Spark 1.3:__
 
@@ -316,6 +392,17 @@ df = sqlContext.load(source="com.databricks.spark.csv", header = 'true', schema 
 df.select('year', 'model').save('newcars.csv', 'com.databricks.spark.csv')
 ```
 
+You can save with compressed output:
+```python
+from pyspark.sql import SQLContext
+sqlContext = SQLContext(sc)
+
+df = sqlContext.load(source="com.databricks.spark.csv", header = 'true', inferSchema = 'true', path = 'cars.csv')
+df.select('year', 'model').save('newcars.csv', 'com.databricks.spark.csv', codec="org.apache.hadoop.io.compress.GzipCodec")
+```
+
+
+
 ### R API
 __Spark 1.4+:__
 
@@ -338,7 +425,7 @@ library(SparkR)
 Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:1.2.0" "sparkr-shell"')
 sqlContext <- sparkRSQL.init(sc)
 customSchema <- structType(
-    structField("year", "integer"), 
+    structField("year", "integer"),
     structField("make", "string"),
     structField("model", "string"),
     structField("comment", "string"),
@@ -347,6 +434,18 @@ customSchema <- structType(
 df <- read.df(sqlContext, "cars.csv", source = "com.databricks.spark.csv", schema = customSchema)
 
 write.df(df, "newcars.csv", "com.databricks.spark.csv", "overwrite")
+```
+
+You can save with compressed output:
+```R
+library(SparkR)
+
+Sys.setenv('SPARKR_SUBMIT_ARGS'='"--packages" "com.databricks:spark-csv_2.10:1.2.0" "sparkr-shell"')
+sqlContext <- sparkRSQL.init(sc)
+
+df <- read.df(sqlContext, "cars.csv", source = "com.databricks.spark.csv", schema = customSchema, inferSchema = "true")
+
+write.df(df, "newcars.csv", "com.databricks.spark.csv", "overwrite", codec="org.apache.hadoop.io.compress.GzipCodec")
 ```
 
 ## Building From Source

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -39,6 +39,7 @@ class CsvParser extends Serializable {
   private var parserLib: String = ParserLibs.DEFAULT
   private var charset: String = TextFile.DEFAULT_CHARSET.name()
   private var inferSchema: Boolean = false
+  private var codec: String = null
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -105,6 +106,11 @@ class CsvParser extends Serializable {
     this
   }
 
+  def withCompression(codec: String): CsvParser = {
+    this.codec = codec
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -122,7 +128,8 @@ class CsvParser extends Serializable {
       ignoreTrailingWhiteSpace,
       treatEmptyValuesAsNulls,
       schema,
-      inferSchema)(sqlContext)
+      inferSchema,
+      codec)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 
@@ -141,7 +148,8 @@ class CsvParser extends Serializable {
       ignoreTrailingWhiteSpace,
       treatEmptyValuesAsNulls,
       schema,
-      inferSchema)(sqlContext)
+      inferSchema,
+      codec)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -318,7 +318,7 @@ case class CsvRelation protected[spark] (
 
       val codecClass = compresionCodecClass(codec)
       data.saveAsCsvFile(filesystemPath.toString, Map("delimiter" -> delimiter.toString),
-                         codecClass)
+        codecClass)
     } else {
       sys.error("CSV tables only support INSERT OVERWRITE for now.")
     }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -45,7 +45,8 @@ case class CsvRelation protected[spark] (
     ignoreTrailingWhiteSpace: Boolean,
     treatEmptyValuesAsNulls: Boolean,
     userSchema: StructType = null,
-    inferCsvSchema: Boolean)(@transient val sqlContext: SQLContext)
+    inferCsvSchema: Boolean,
+    codec: String = null)(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with PrunedScan with InsertableRelation {
 
   /**
@@ -314,7 +315,10 @@ case class CsvRelation protected[spark] (
               + s" to INSERT OVERWRITE a CSV table:\n${e.toString}")
       }
       // Write the data. We assume that schema isn't changed, and we won't update it.
-      data.saveAsCsvFile(filesystemPath.toString, Map("delimiter" -> delimiter.toString))
+
+      val codecClass = compresionCodecClass(codec)
+      data.saveAsCsvFile(filesystemPath.toString, Map("delimiter" -> delimiter.toString),
+                         codecClass)
     } else {
       sys.error("CSV tables only support INSERT OVERWRITE for now.")
     }

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -135,6 +135,8 @@ class DefaultSource
       throw new Exception("Infer schema flag can be true or false")
     }
 
+    val codec = parameters.getOrElse("codec", null)
+
     CsvRelation(
       () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
       Some(path),
@@ -149,7 +151,8 @@ class DefaultSource
       ignoreTrailingWhiteSpaceFlag,
       treatEmptyValuesAsNullsFlag,
       schema,
-      inferSchemaFlag)(sqlContext)
+      inferSchemaFlag,
+      codec)(sqlContext)
   }
 
   override def createRelation(
@@ -176,7 +179,8 @@ class DefaultSource
     }
     if (doSave) {
       // Only save data when the save mode is not ignore.
-      data.saveAsCsvFile(path, parameters)
+      val codecClass = compresionCodecClass(parameters.getOrElse("codec", null))
+      data.saveAsCsvFile(path, parameters, codecClass)
     }
 
     createRelation(sqlContext, parameters, data.schema)

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -90,15 +90,40 @@ package object csv {
 
     /**
      * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
+     * The resulting output will not be compressed.
      */
-    def saveAsCsvFile(path: String, parameters: Map[String, String] = Map()): Unit = {
-      // TODO(hossein): For nested types, we may want to perform special work
-      val codecStr =  parameters.getOrElse("compressionCodec", null)
-      val compressionCodec = if (codecStr == null) {
-        null
-      } else{
-        Class.forName(codecStr).asInstanceOf[Class[CompressionCodec]]
+    def saveAsCsvFile(path: String) : Unit = {
+        saveAsCsvFile(path, Map(), null)
+    }
+
+    /**
+     * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
+     * If the parameters Map contains the key "compressionCodec" with a value
+     * corresponding to the name of a class implementing
+     * org.apache.hadoop.io.compress.CompressionCodec then the output will be
+     * compressed.
+     */
+    def saveAsCsvFile(path: String, parameters: Map[String, String]): Unit = {
+      val codecStr = parameters.getOrElse("compressionCodec", null)
+      if (codecStr == null) {
+        saveAsCsvFile(path, parameters, null)
+      } else {
+        saveAsCsvFile(path, parameters,
+          // scalastyle:off classforname
+          Class.forName(codecStr).asInstanceOf[Class[CompressionCodec]])
+          // scalastyle:on classforname
       }
+    }
+
+
+    /**
+     * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
+     * If compressionCodec is not null the resulting output will be compressed.
+     * Note that a compressionCodec entry in the parameters map will be ignored.
+     */
+    def saveAsCsvFile(path: String, parameters: Map[String, String] = Map(),
+                      compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
+      // TODO(hossein): For nested types, we may want to perform special work
       val delimiter = parameters.getOrElse("delimiter", ",")
       val delimiterChar = if (delimiter.length == 1) {
         delimiter.charAt(0)

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -91,9 +91,14 @@ package object csv {
     /**
      * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
      */
-    def saveAsCsvFile(path: String, parameters: Map[String, String] = Map(),
-                      compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
+    def saveAsCsvFile(path: String, parameters: Map[String, String] = Map()): Unit = {
       // TODO(hossein): For nested types, we may want to perform special work
+      val codecStr =  parameters.getOrElse("compressionCodec", null)
+      val compressionCodec = if (codecStr == null) {
+        null
+      } else{
+        Class.forName(codecStr).asInstanceOf[Class[CompressionCodec]]
+      }
       val delimiter = parameters.getOrElse("delimiter", ",")
       val delimiterChar = if (delimiter.length == 1) {
         delimiter.charAt(0)

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -26,6 +26,16 @@ package object csv {
   val defaultCsvFormat =
     CSVFormat.DEFAULT.withRecordSeparator(System.getProperty("line.separator", "\n"))
 
+  private[csv] def compresionCodecClass(className: String): Class[_ <: CompressionCodec] = {
+    className match {
+    case null => null
+    case codec =>
+      // scalastyle:off classforname
+      Class.forName(codec).asInstanceOf[Class[CompressionCodec]]
+      // scalastyle:on classforname
+    }
+  }
+
   /**
    * Adds a method, `csvFile`, to SQLContext that allows reading CSV data.
    */
@@ -87,34 +97,6 @@ package object csv {
   }
 
   implicit class CsvSchemaRDD(dataFrame: DataFrame) {
-
-    /**
-     * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
-     * The resulting output will not be compressed.
-     */
-    def saveAsCsvFile(path: String) : Unit = {
-        saveAsCsvFile(path, Map(), null)
-    }
-
-    /**
-     * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
-     * If the parameters Map contains the key "compressionCodec" with a value
-     * corresponding to the name of a class implementing
-     * org.apache.hadoop.io.compress.CompressionCodec then the output will be
-     * compressed.
-     */
-    def saveAsCsvFile(path: String, parameters: Map[String, String]): Unit = {
-      val codecStr = parameters.getOrElse("compressionCodec", null)
-      if (codecStr == null) {
-        saveAsCsvFile(path, parameters, null)
-      } else {
-        saveAsCsvFile(path, parameters,
-          // scalastyle:off classforname
-          Class.forName(codecStr).asInstanceOf[Class[CompressionCodec]])
-          // scalastyle:on classforname
-      }
-    }
-
 
     /**
      * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -28,11 +28,11 @@ package object csv {
 
   private[csv] def compresionCodecClass(className: String): Class[_ <: CompressionCodec] = {
     className match {
-    case null => null
-    case codec =>
-      // scalastyle:off classforname
-      Class.forName(codec).asInstanceOf[Class[CompressionCodec]]
-      // scalastyle:on classforname
+      case null => null
+      case codec =>
+        // scalastyle:off classforname
+        Class.forName(codec).asInstanceOf[Class[CompressionCodec]]
+        // scalastyle:on classforname
     }
   }
 
@@ -101,7 +101,7 @@ package object csv {
     /**
      * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
      * If compressionCodec is not null the resulting output will be compressed.
-     * Note that a compressionCodec entry in the parameters map will be ignored.
+     * Note that a codec entry in the parameters map will be ignored.
      */
     def saveAsCsvFile(path: String, parameters: Map[String, String] = Map(),
                       compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -409,7 +409,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "cars-copy.csv"
 
     val cars = sqlContext.csvFile(carsFile, parserLib = parserLib)
-    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true"), classOf[GzipCodec])
+    cars.saveAsCsvFile(copyFilePath, Map("header" -> "true", "compressionCodec" -> classOf[GzipCodec].getName))
 
     val carsCopy = sqlContext.csvFile(copyFilePath + "/")
 


### PR DESCRIPTION
This change allows Python (and presumably Java) users to use compressed
output by passing the compressionCodec as a string option, instead of an
argument to a function only visible in the implicit class.

This is an API breaking change, so I'm definitely open to other
approaches.
