### PR TITLE
Add escape feature to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ This package allows reading CSV files in local or distributed filesystem as [Spa
 When reading files the API accepts several options:
 * `path`: location of files. Similar to Spark can accept standard Hadoop globbing expressions.
 * `header`: when set to true the first line of files will be used to name columns and will not be included in data. All types will be assumed string. Default value is false.
-* `delimiter`: by default columns are delimited using ',', but delimiter can be set to any character
-* `quote`: by default the quote character is '"', but can be set to any character. Delimiters inside quotes are ignored
+* `delimiter`: by default columns are delimited using `,`, but delimiter can be set to any character
+* `quote`: by default the quote character is `"`, but can be set to any character. Delimiters inside quotes are ignored
 * `parserLib`: by default it is "commons" can be set to "univocity" to use that library for CSV parsing.
 * `mode`: determines the parsing mode. By default it is PERMISSIVE. Possible values are:
   * `PERMISSIVE`: tries to parse all lines: nulls are inserted for missing tokens and extra tokens are ignored.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ When reading files the API accepts several options:
 * `header`: when set to true the first line of files will be used to name columns and will not be included in data. All types will be assumed string. Default value is false.
 * `delimiter`: by default columns are delimited using `,`, but delimiter can be set to any character
 * `quote`: by default the quote character is `"`, but can be set to any character. Delimiters inside quotes are ignored
+* `escape`: by default the escape character is `\`, but can be set to any character. Escaped quote characters are ignored
 * `parserLib`: by default it is "commons" can be set to "univocity" to use that library for CSV parsing.
 * `mode`: determines the parsing mode. By default it is PERMISSIVE. Possible values are:
   * `PERMISSIVE`: tries to parse all lines: nulls are inserted for missing tokens and extra tokens are ignored.


### PR DESCRIPTION
The documentation was missing the escape character that's available through `CsvParser.withEscape`