### PR TITLE
Exposed parameter for univosity maximum number of characters per column.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ When reading files the API accepts several options:
 * `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec`. Defaults to no compression when a codec is not specified.
+* `maxCharsPerColumn`: (note for **univocity** parser only). Controls the maximum number of characters allowed in each column. It's set to 100000 by default.
 
 The package also support saving simple (non-nested) DataFrame. When saving you can specify the delimiter and whether we should generate a header row for the table. See following examples for more details.
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "spark-csv"
 
-version := "1.3.0"
+version := "1.4.0-SNAPSHOT"
 
 organization := "com.databricks"
 
@@ -50,6 +50,7 @@ publishTo := {
     Some("releases"  at nexus + "service/local/staging/deploy/maven2")
 }
 
+
 pomExtra := (
   <url>https://github.com/databricks/spark-csv</url>
   <licenses>
@@ -89,7 +90,7 @@ import com.typesafe.tools.mima.plugin.MimaKeys.previousArtifact
 import com.typesafe.tools.mima.plugin.MimaPlugin.mimaDefaultSettings
 
 mimaDefaultSettings ++ Seq(
-  previousArtifact := Some("com.databricks" %% "spark-csv" % "1.2.0"),
+  previousArtifact := Some("com.databricks" %% "spark-csv" % "1.3.0"),
   binaryIssueFilters ++= Seq(
     // These classes are not intended to be public interfaces:
     ProblemFilters.excludePackage("com.databricks.spark.csv.CsvRelation"),

--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -40,6 +40,7 @@ class CsvParser extends Serializable {
   private var charset: String = TextFile.DEFAULT_CHARSET.name()
   private var inferSchema: Boolean = false
   private var codec: String = null
+  private var maxCharsPerColumn: Int = 100000
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -111,6 +112,11 @@ class CsvParser extends Serializable {
     this
   }
 
+  def withMaxCharsPerColumn(maxLength: Int): CsvParser = {
+    this.maxCharsPerColumn = maxLength
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -129,7 +135,8 @@ class CsvParser extends Serializable {
       treatEmptyValuesAsNulls,
       schema,
       inferSchema,
-      codec)(sqlContext)
+      codec,
+      maxCharsPerColumn)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 
@@ -149,7 +156,8 @@ class CsvParser extends Serializable {
       treatEmptyValuesAsNulls,
       schema,
       inferSchema,
-      codec)(sqlContext)
+      codec,
+      maxCharsPerColumn)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -46,7 +46,8 @@ case class CsvRelation protected[spark] (
     treatEmptyValuesAsNulls: Boolean,
     userSchema: StructType = null,
     inferCsvSchema: Boolean,
-    codec: String = null)(@transient val sqlContext: SQLContext)
+    codec: String = null,
+    maxCharsPerColumn: Int)(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with PrunedScan with InsertableRelation {
 
   /**
@@ -213,7 +214,8 @@ case class CsvRelation protected[spark] (
           fieldSep = delimiter,
           quote = quoteChar,
           escape = escapeVal,
-          commentMarker = commentChar).parseLine(firstLine)
+          commentMarker = commentChar,
+          maxCharsPerColumn = maxCharsPerColumn).parseLine(firstLine)
       } else {
         val csvFormat = defaultCsvFormat
           .withDelimiter(delimiter)
@@ -267,7 +269,8 @@ case class CsvRelation protected[spark] (
 
         new BulkCsvReader(iter, split,
           headers = header, fieldSep = delimiter,
-          quote = quoteChar, escape = escapeVal, commentMarker = commentChar)
+          quote = quoteChar, escape = escapeVal, commentMarker = commentChar,
+          maxCharsPerColumn = maxCharsPerColumn)
       }
     }, true)
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -47,7 +47,7 @@ case class CsvRelation protected[spark] (
     userSchema: StructType = null,
     inferCsvSchema: Boolean,
     codec: String = null,
-    maxCharsPerColumn: Int)(@transient val sqlContext: SQLContext)
+    maxCharsPerColumn: Int = 100000)(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with PrunedScan with InsertableRelation {
 
   /**

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -139,6 +139,8 @@ class DefaultSource
 
     val codec = parameters.getOrElse("codec", null)
 
+    val maxCharsPerColumn = parameters.get("maxCharsPerColumn").map(_.toInt).getOrElse(100000)
+
     CsvRelation(
       () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
       Some(path),
@@ -154,7 +156,8 @@ class DefaultSource
       treatEmptyValuesAsNullsFlag,
       schema,
       inferSchemaFlag,
-      codec)(sqlContext)
+      codec,
+      maxCharsPerColumn)(sqlContext)
   }
 
   override def createRelation(

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -52,7 +52,8 @@ package object csv {
         ignoreLeadingWhiteSpace: Boolean = false,
         ignoreTrailingWhiteSpace: Boolean = false,
         charset: String = TextFile.DEFAULT_CHARSET.name(),
-        inferSchema: Boolean = false): DataFrame = {
+        inferSchema: Boolean = false,
+        maxCharsPerColumn: Int = 100000): DataFrame = {
       val csvRelation = CsvRelation(
         () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
         location = Some(filePath),
@@ -66,7 +67,8 @@ package object csv {
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
         treatEmptyValuesAsNulls = false,
-        inferCsvSchema = inferSchema)(sqlContext)
+        inferCsvSchema = inferSchema,
+        maxCharsPerColumn = maxCharsPerColumn)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
@@ -77,7 +79,8 @@ package object csv {
         ignoreLeadingWhiteSpace: Boolean = false,
         ignoreTrailingWhiteSpace: Boolean = false,
         charset: String = TextFile.DEFAULT_CHARSET.name(),
-        inferSchema: Boolean = false): DataFrame = {
+        inferSchema: Boolean = false,
+        maxCharsPerColumn: Int = 100000): DataFrame = {
       val csvRelation = CsvRelation(
         () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
         location = Some(filePath),
@@ -91,7 +94,8 @@ package object csv {
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
         treatEmptyValuesAsNulls = false,
-        inferCsvSchema = inferSchema)(sqlContext)
+        inferCsvSchema = inferSchema,
+        maxCharsPerColumn = maxCharsPerColumn)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -52,8 +52,7 @@ package object csv {
         ignoreLeadingWhiteSpace: Boolean = false,
         ignoreTrailingWhiteSpace: Boolean = false,
         charset: String = TextFile.DEFAULT_CHARSET.name(),
-        inferSchema: Boolean = false,
-        maxCharsPerColumn: Int = 100000): DataFrame = {
+        inferSchema: Boolean = false): DataFrame = {
       val csvRelation = CsvRelation(
         () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
         location = Some(filePath),
@@ -67,8 +66,7 @@ package object csv {
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
         treatEmptyValuesAsNulls = false,
-        inferCsvSchema = inferSchema,
-        maxCharsPerColumn = maxCharsPerColumn)(sqlContext)
+        inferCsvSchema = inferSchema)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
@@ -79,8 +77,7 @@ package object csv {
         ignoreLeadingWhiteSpace: Boolean = false,
         ignoreTrailingWhiteSpace: Boolean = false,
         charset: String = TextFile.DEFAULT_CHARSET.name(),
-        inferSchema: Boolean = false,
-        maxCharsPerColumn: Int = 100000): DataFrame = {
+        inferSchema: Boolean = false): DataFrame = {
       val csvRelation = CsvRelation(
         () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
         location = Some(filePath),
@@ -94,8 +91,7 @@ package object csv {
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
         treatEmptyValuesAsNulls = false,
-        inferCsvSchema = inferSchema,
-        maxCharsPerColumn = maxCharsPerColumn)(sqlContext)
+        inferCsvSchema = inferSchema)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/readers/readers.scala
+++ b/src/main/scala/com/databricks/spark/csv/readers/readers.scala
@@ -44,7 +44,8 @@ private[readers] abstract class CsvReader(
     ignoreTrailingSpace: Boolean = true,
     headers: Seq[String],
     inputBufSize: Int = 128,
-    maxCols: Int = 20480) {
+    maxCols: Int = 20480,
+    maxCharsPerColumn: Int) {
   protected lazy val parser: CsvParser = {
     val settings = new CsvParserSettings()
     val format = settings.getFormat
@@ -59,7 +60,7 @@ private[readers] abstract class CsvReader(
     settings.setInputBufferSize(inputBufSize)
     settings.setMaxColumns(maxCols)
     settings.setNullValue("")
-    settings.setMaxCharsPerColumn(100000)
+    settings.setMaxCharsPerColumn(maxCharsPerColumn)
     if (headers != null) settings.setHeaders(headers: _*)
 
     new CsvParser(settings)
@@ -86,7 +87,8 @@ private[csv] class LineCsvReader(
     ignoreLeadingSpace: Boolean = true,
     ignoreTrailingSpace: Boolean = true,
     inputBufSize: Int = 128,
-    maxCols: Int = 20480)
+    maxCols: Int = 20480,
+    maxCharsPerColumn: Int)
   extends CsvReader(
     fieldSep,
     lineSep,
@@ -97,7 +99,8 @@ private[csv] class LineCsvReader(
     ignoreTrailingSpace,
     null,
     inputBufSize,
-    maxCols) {
+    maxCols,
+    maxCharsPerColumn) {
   /**
    * parse a line
    * @param line a String with no newline at the end
@@ -136,7 +139,8 @@ private[csv] class BulkCsvReader(
     ignoreTrailingSpace: Boolean = true,
     headers: Seq[String],
     inputBufSize: Int = 128,
-    maxCols: Int = 20480)
+    maxCols: Int = 20480,
+    maxCharsPerColumn: Int)
   extends CsvReader(
     fieldSep,
     lineSep,
@@ -147,7 +151,8 @@ private[csv] class BulkCsvReader(
     ignoreTrailingSpace,
     headers,
     inputBufSize,
-    maxCols)
+    maxCols,
+    maxCharsPerColumn)
   with Iterator[Array[String]] {
 
   private val reader = new StringIteratorReader(iter)


### PR DESCRIPTION
#### Description
While using the `spark-csv` library with the Univosity parser, we ran into problems when parsing lines with really long columns.
This was due to a predefined limit on the column length that is required by Univosity.

This PR extracts that configuration at the `spark-csv` top level so that it can be changed.

* Added configuration parameter `maxCharsPerColumn` with the same default value of `100000` as it was before.
* Added unit test to cover for the case
* The parameter only applies for the univosity parser and is ignored for the commons parser. This was explained in the README file as well.