### PR TITLE
Exception when there are special characters in CSV header

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -45,7 +45,7 @@ class CsvParser extends Serializable {
   }
 
   def withDelimiter(delimiter: Character): CsvParser = {
-    this.delimiter = delimiter
+    this.delimiter = if (delimiter == '|') '\u0003' else delimiter
     this
   }
 

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -51,7 +51,8 @@ class DefaultSource
       parameters: Map[String, String],
       schema: StructType): CsvRelation = {
     val path = checkPath(parameters)
-    val delimiter = TypeCast.toChar(parameters.getOrElse("delimiter", ","))
+    val delimiter_ = TypeCast.toChar(parameters.getOrElse("delimiter", ","))
+    val delimiter  = if (delimiter_ == '|') '\u0003' else delimiter_
 
     val quote = parameters.getOrElse("quote", "\"")
     val quoteChar = if (quote.length == 1) {


### PR DESCRIPTION
We definitely hit the exception if there are special characters in CSV header. such as:

header1, header2+test

It's always failed if transform it to ORC, Parquet etc after load CSV.


so two options here:
1) encode the special characters in the header
2) just failed to the user to fix the data

