### PR TITLE
Fix another Java example of custom schemas.

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,13 +270,13 @@ import org.apache.spark.sql.SQLContext;
 import org.apache.spark.sql.types.*;
 
 SQLContext sqlContext = new SQLContext(sc);
-StructType customSchema = new StructType(
-    new StructField("year", IntegerType, true),
-    new StructField("make", StringType, true),
-    new StructField("model", StringType, true),
-    new StructField("comment", StringType, true),
-    new StructField("blank", StringType, true));
-
+StructType customSchema = new StructType(new StructField[] {
+    new StructField("year", DataTypes.IntegerType, true, Metadata.empty()),
+    new StructField("make", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("model", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("comment", DataTypes.StringType, true, Metadata.empty()),
+    new StructField("blank", DataTypes.StringType, true, Metadata.empty())
+});
 
 HashMap<String, String> options = new HashMap<String, String>();
 options.put("header", "true");


### PR DESCRIPTION
It is a ditto with https://github.com/databricks/spark-csv/pull/213

The example for Spark 1.3 also has to be updated.