### PR TITLE
Support for dropping malformed rows for TimestampType and DateType types

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -124,18 +124,13 @@ case class CsvRelation protected[spark] (
           case aiob: ArrayIndexOutOfBoundsException if permissive =>
             (index until schemaFields.length).foreach(ind => rowArray(ind) = null)
             Some(Row.fromSeq(rowArray))
-          case nfe: java.lang.NumberFormatException if dropMalformed =>
+          case _: java.lang.NumberFormatException |
+               _: IllegalArgumentException if dropMalformed =>
             logger.warn("Number format exception. " +
               s"Dropping malformed line: ${tokens.mkString(",")}")
             None
           case pe: java.text.ParseException if dropMalformed =>
             logger.warn("Parse exception. " +
-              s"Dropping malformed line: ${tokens.mkString(",")}")
-            None
-          // When the function `valueOf` in Timestamp or Date fails,
-          // this emits IllegalArgumentException.
-          case iae: IllegalArgumentException if dropMalformed =>
-            logger.warn("Illegal argument exception. " +
               s"Dropping malformed line: ${tokens.mkString(",")}")
             None
         }
@@ -197,8 +192,9 @@ case class CsvRelation protected[spark] (
               logger.warn("Number format exception. " +
                 s"Dropping malformed line: ${tokens.mkString(delimiter.toString)}")
               None
-            case pe: java.text.ParseException if dropMalformed =>
-              logger.warn("Parse Exception. " +
+            case _: java.lang.NumberFormatException |
+                 _: IllegalArgumentException if dropMalformed =>
+              logger.warn("Parse exception. " +
                 s"Dropping malformed line: ${tokens.mkString(delimiter.toString)}")
               None
           }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -129,7 +129,13 @@ case class CsvRelation protected[spark] (
               s"Dropping malformed line: ${tokens.mkString(",")}")
             None
           case pe: java.text.ParseException if dropMalformed =>
-            logger.warn("Parse Exception. " +
+            logger.warn("Parse exception. " +
+              s"Dropping malformed line: ${tokens.mkString(",")}")
+            None
+          // When the function `valueOf` in Timestamp or Date fails,
+          // this emits IllegalArgumentException.
+          case iae: IllegalArgumentException if dropMalformed =>
+            logger.warn("Illegal argument exception. " +
               s"Dropping malformed line: ${tokens.mkString(",")}")
             None
         }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -127,11 +127,11 @@ case class CsvRelation protected[spark] (
           case _: java.lang.NumberFormatException |
                _: IllegalArgumentException if dropMalformed =>
             logger.warn("Number format exception. " +
-              s"Dropping malformed line: ${tokens.mkString(",")}")
+              s"Dropping malformed line: ${tokens.mkString(delimiter.toString)}")
             None
           case pe: java.text.ParseException if dropMalformed =>
             logger.warn("Parse exception. " +
-              s"Dropping malformed line: ${tokens.mkString(",")}")
+              s"Dropping malformed line: ${tokens.mkString(delimiter.toString)}")
             None
         }
       }
@@ -188,12 +188,12 @@ case class CsvRelation protected[spark] (
             }
             Some(Row.fromSeq(rowArray))
           } catch {
-            case nfe: java.lang.NumberFormatException if dropMalformed =>
+            case _: java.lang.NumberFormatException |
+                 _: IllegalArgumentException if dropMalformed =>
               logger.warn("Number format exception. " +
                 s"Dropping malformed line: ${tokens.mkString(delimiter.toString)}")
               None
-            case _: java.lang.NumberFormatException |
-                 _: IllegalArgumentException if dropMalformed =>
+            case pe: java.text.ParseException if dropMalformed =>
               logger.warn("Parse exception. " +
                 s"Dropping malformed line: ${tokens.mkString(delimiter.toString)}")
               None

--- a/src/test/resources/ages.csv
+++ b/src/test/resources/ages.csv
@@ -1,4 +1,5 @@
-Name,Age,Height
-Bob,10,180
-Joe,20.5,200
-Tom,30,Dan
+Name,Age,Height,Born
+Bob,10,180,Unknown
+Joe,20.5,200,1995-01-01 00:00:00
+Tom,30,Dan,1985-01-01 00:00:00
+Hyukjin,25,165,1990-02-24 00:00:00

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -306,7 +306,8 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       Array(
         StructField("Name", StringType, true),
         StructField("Age", StringType, true),
-        StructField("Height", StringType, true)
+        StructField("Height", StringType, true),
+        StructField("Born", StringType, true)
       )
     )
 
@@ -318,14 +319,16 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       .csvFile(sqlContext, ageFile)
       .count()
 
-    assert(results === 3)
+    assert(results === 4)
   }
+
   test("DSL test with poorly formatted file and known schema") {
     val strictSchema = new StructType(
       Array(
         StructField("Name", StringType, true),
         StructField("Age", IntegerType, true),
-        StructField("Height", DoubleType, true)
+        StructField("Height", DoubleType, true),
+        StructField("Born", TimestampType, true)
       )
     )
 

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -174,7 +174,8 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       Array(
         StructField("Name", StringType, true),
         StructField("Age", IntegerType, true),
-        StructField("Height", DoubleType, true)
+        StructField("Height", DoubleType, true),
+        StructField("Born", TimestampType, true)
       )
     )
 


### PR DESCRIPTION
In this PR, I added some logics to catch `IllegalArgumentException`. When trying to parse malformed data to `TimestampType` or `DateType`, it emits the exception with the message below. 

```
java.lang.IllegalArgumentException
	at java.sql.Date.valueOf(Date.java:143)
	at com.databricks.spark.csv.util.TypeCast$.castTo(TypeCast.scala:64)
	at com.databricks.spark.csv.CsvRelation$$anonfun$buildScan$6.apply(CsvRelation.scala:188)
	at com.databricks.spark.csv.CsvRelation$$anonfun$buildScan$6.apply(CsvRelation.scala:169)
	at scala.collection.Iterator$$anon$12.hasNext(Iterator.scala:396)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:369)
	...
```

So, because of this, dropping malformed rows does not work properly.