### PR TITLE
allow HadoopRDDs minPartitions to be specified

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -41,6 +41,7 @@ class CsvParser extends Serializable {
   private var inferSchema: Boolean = false
   private var codec: String = null
   private var nullValue: String = ""
+  private var minPartitions: Int = 0
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -117,11 +118,16 @@ class CsvParser extends Serializable {
     this
   }
 
+  def withMinPartitions(minPartitions: Int): CsvParser = {
+    this.minPartitions = minPartitions
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
     val relation: CsvRelation = CsvRelation(
-      () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
+      () => TextFile.withCharset(sqlContext.sparkContext, path, charset, minPartitions),
       Some(path),
       useHeader,
       delimiter,

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -140,8 +140,10 @@ class DefaultSource
 
     val codec = parameters.getOrElse("codec", null)
 
+    val minPartitions = parameters.get("minPartitions").map(_.toInt).getOrElse(0)
+
     CsvRelation(
-      () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
+      () => TextFile.withCharset(sqlContext.sparkContext, path, charset, minPartitions),
       Some(path),
       headerFlag,
       delimiter,

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -52,9 +52,10 @@ package object csv {
         ignoreLeadingWhiteSpace: Boolean = false,
         ignoreTrailingWhiteSpace: Boolean = false,
         charset: String = TextFile.DEFAULT_CHARSET.name(),
-        inferSchema: Boolean = false): DataFrame = {
+        inferSchema: Boolean = false,
+        minPartitions: Int = 0): DataFrame = {
       val csvRelation = CsvRelation(
-        () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
+        () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset, minPartitions),
         location = Some(filePath),
         useHeader = useHeader,
         delimiter = delimiter,
@@ -77,9 +78,10 @@ package object csv {
         ignoreLeadingWhiteSpace: Boolean = false,
         ignoreTrailingWhiteSpace: Boolean = false,
         charset: String = TextFile.DEFAULT_CHARSET.name(),
-        inferSchema: Boolean = false): DataFrame = {
+        inferSchema: Boolean = false,
+        minPartitions: Int = 0): DataFrame = {
       val csvRelation = CsvRelation(
-        () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset),
+        () => TextFile.withCharset(sqlContext.sparkContext, filePath, charset, minPartitions),
         location = Some(filePath),
         useHeader = useHeader,
         delimiter = '\t',

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -49,31 +49,31 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("read utf-8 encoded file") {
-    val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8)
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8, 0)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
   }
 
   test("read utf-8 encoded file using charset alias") {
-    val baseRDD = TextFile.withCharset(sparkContext, carsFile, "utf8")
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile, "utf8", 0)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
   }
 
   test("read iso-8859-1 encoded file") {
-    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, iso88591)
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, iso88591, 0)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == smallThorn) == numColumns)
   }
 
   test("read iso-8859-1 encoded file using charset alias") {
-    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, "8859_1")
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, "8859_1", 0)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == smallThorn) == numColumns)
   }
 
   test("read iso-8859-1 encoded file with invalid charset") {
-    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, utf8)
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile8859, utf8, 0)
     assert(baseRDD.count() === numLines)
     // file loads but since it's not encoded in utf-8, non-ascii characters are not decoded
     // correctly.
@@ -82,8 +82,14 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
 
   test("unsupported charset") {
     val exception = intercept[UnsupportedCharsetException] {
-      TextFile.withCharset(sparkContext, carsFile, "frylock").count()
+      TextFile.withCharset(sparkContext, carsFile, "frylock", 0).count()
     }
     assert(exception.getMessage.contains("frylock"))
   }
+
+  test("read with minPartitions specified") {
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8, 3)
+    assert(baseRDD.getNumPartitions === 3)
+  }
+
 }


### PR DESCRIPTION
We had a need for this to get to a desired number of partitions without a shuffle.

Not sure if this is useful for others as well.