### PR TITLE
Deprecated DecimalType.Unlimited val was removed in Spark 2.0.0

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -142,7 +142,7 @@ private[csv] object InferSchema {
       FloatType,
       DoubleType,
       TimestampType,
-      DecimalType.Unlimited)
+      DecimalType.SYSTEM_DEFAULT)
 
   /**
    * Copied from internal Spark api


### PR DESCRIPTION
See https://github.com/apache/spark/commit/77ab49b8575d2ebd678065fa70b0343d532ab9c2#diff-562cf76d70c7e4f4b4d163b13f67e337L126