### PR TITLE
Validation for supported encodings (except non-ascii compatible encodings) and some stylistic corrections. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,20 +43,20 @@ This package allows reading CSV files in local or distributed filesystem as [Spa
 When reading files the API accepts several options:
 * `path`: location of files. Similar to Spark can accept standard Hadoop globbing expressions.
 * `header`: when set to true the first line of files will be used to name columns and will not be included in data. All types will be assumed string. Default value is false.
-* `delimiter`: by default columns are delimited using `,`, but delimiter can be set to any character
-* `quote`: by default the quote character is `"`, but can be set to any character. Delimiters inside quotes are ignored
-* `escape`: by default the escape character is `\`, but can be set to any character. Escaped quote characters are ignored
+* `delimiter`: by default columns are delimited using `,`, but delimiter can be set to any character.
+* `quote`: by default the quote character is `"`, but can be set to any character. Delimiters inside quotes are ignored.
+* `escape`: by default the escape character is `\`, but can be set to any character. Escaped quote characters are ignored.
 * `parserLib`: by default it is "commons" can be set to "univocity" to use that library for CSV parsing.
 * `mode`: determines the parsing mode. By default it is PERMISSIVE. Possible values are:
   * `PERMISSIVE`: tries to parse all lines: nulls are inserted for missing tokens and extra tokens are ignored.
   * `DROPMALFORMED`: drops lines which have fewer or more tokens than expected or tokens which do
-   not match the schema
-  * `FAILFAST`: aborts with a RuntimeException if encounters any malformed line
-* `charset`: defaults to 'UTF-8' but can be set to other valid charset names
-* `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default
+   not match the schema.
+  * `FAILFAST`: aborts with a RuntimeException if encounters any malformed line.
+* `charset`: defaults to 'UTF-8' but can be set to other valid charset names. This library does not support non-ascii compatible encodings (UTF-16/32 etc.).
+* `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default.
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
-* `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
+* `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame.
 
 The package also support saving simple (non-nested) DataFrame. When saving you can specify the delimiter and whether we should generate a header row for the table. See following examples for more details.
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -240,7 +240,7 @@ case class CsvRelation protected[spark] (
         firstRow.zipWithIndex.map { case (value, index) => s"C$index"}
       }
       if (this.inferCsvSchema) {
-        InferSchema(tokenRdd(header), header, nullValue)
+        InferSchema.infer(tokenRdd(header), header, nullValue)
       } else {
         // By default fields are assumed to be StringType
         val schemaFields = header.map { fieldName =>

--- a/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala
@@ -31,7 +31,7 @@ private[csv] object InferSchema {
    *     2. Merge row types to find common type
    *     3. Replace any null types with string type
    */
-  def apply(
+  def infer(
     tokenRdd: RDD[Array[String]],
     header: Array[String],
     nullValue: String = ""): StructType = {

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -29,9 +29,9 @@ private[csv] object TextFile {
     val checkedCharset = {
       val charsetObj = Charset.forName(charset)
       val lineSeq = "\n"
-      val isAsciiCapable =
+      val isASCIICompatible =
         java.util.Arrays.equals(lineSeq.getBytes(DEFAULT_CHARSET), lineSeq.getBytes(charsetObj))
-      if (!isAsciiCapable) {
+      if (!isASCIICompatible) {
         throw new UnsupportedCharsetException(charsetObj.name())
       } else {
         charsetObj

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -92,6 +92,16 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
     assert(exception.getMessage.contains("1-9588-osi"))
   }
 
+  test("DSL test non-ascii capable charset name") {
+    val exception = intercept[UnsupportedCharsetException] {
+      val results = sqlContext
+        .csvFile(carsFile8859, parserLib = parserLib, charset = "utf-32")
+        .select("year")
+        .collect()
+    }
+    assert(exception.getMessage.contains("UTF-32"))
+  }
+
   test("DDL test") {
     sqlContext.sql(
       s"""

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -86,4 +86,11 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
     }
     assert(exception.getMessage.contains("frylock"))
   }
+
+  test("unsupported non-ascii capable charset") {
+    val exception = intercept[UnsupportedCharsetException] {
+      TextFile.withCharset(sparkContext, carsFile, "utf-16").count()
+    }
+    assert(exception.getMessage.contains("UTF-16"))
+  }
 }


### PR DESCRIPTION
#231 

As this library does not support some non-ascii compatible encodings, this is described in `README.md`.

Also, `InferSchema` has the function `infer()` instead of `apply()` as it does not return the corresponding object.
This is not recommended according to [databricks/scala-style-guide/README.md#apply_method] (https://github.com/databricks/scala-style-guide/blob/master/README.md#apply_method)
