### PR TITLE
NullPoingException in schema inference for CSV when the first line is empty

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -50,11 +50,6 @@ case class CsvRelation protected[spark] (
     nullValue: String = "")(@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with PrunedScan with InsertableRelation {
 
-  /**
-   * Limit the number of lines we'll search for a header row that isn't comment-prefixed.
-   */
-  private val MAX_COMMENT_LINES_IN_HEADER = 10
-
   private val logger = LoggerFactory.getLogger(CsvRelation.getClass)
 
   // Parse mode flags
@@ -255,13 +250,14 @@ case class CsvRelation protected[spark] (
    * Returns the first line of the first non-empty file in path
    */
   private lazy val firstLine = {
-    if (comment == null) {
-      baseRDD().first()
+    if (comment != null) {
+      baseRDD().filter { line =>
+        line.trim.nonEmpty && !line.startsWith(comment.toString)
+      }.first()
     } else {
-      baseRDD().take(MAX_COMMENT_LINES_IN_HEADER)
-        .find(! _.startsWith(comment.toString))
-        .getOrElse(sys.error(s"No uncommented header line in " +
-          s"first $MAX_COMMENT_LINES_IN_HEADER lines"))
+      baseRDD().filter { line =>
+        line.trim.nonEmpty
+      }.first()
     }
   }
 

--- a/src/test/resources/ages.csv
+++ b/src/test/resources/ages.csv
@@ -1,3 +1,4 @@
+
 Name,Age,Height,Born
 Bob,10,180,Unknown
 Joe,20.5,200,1995-01-01 00:00:00

--- a/src/test/resources/cars.csv
+++ b/src/test/resources/cars.csv
@@ -1,3 +1,4 @@
+
 year,make,model,comment,blank
 "2012","Tesla","S","No comment",
 

--- a/src/test/resources/cars.csv
+++ b/src/test/resources/cars.csv
@@ -1,4 +1,3 @@
-
 year,make,model,comment,blank
 "2012","Tesla","S","No comment",
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/SPARK-13137

This PR adds a filter in schema inference so that it does not emit NullPointException.

Also, I removed `MAX_COMMENT_LINES_IN_HEADER `but instead used a monad chaining with `filter()` and `first()`.

Lastly, I simply added a newline rather than adding a new file for this so that this is covered with the original tests.