### PR TITLE
support for passing minPartitions when reading file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ When reading files the API accepts several options:
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 * `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
+* `minPartitions`: determines into how many partitions the file is divided
 
 The package also support saving simple (non-nested) DataFrame. When saving you can specify the delimiter and whether we should generate a header row for the table. See following examples for more details.
 

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -139,9 +139,11 @@ class DefaultSource
     val nullValue = parameters.getOrElse("nullValue", "")
 
     val codec = parameters.getOrElse("codec", null)
+    val minPartitions: Integer = parameters.getOrElse("minPartitions",
+      sqlContext.sparkContext.defaultMinPartitions.toString).toInt
 
     CsvRelation(
-      () => TextFile.withCharset(sqlContext.sparkContext, path, charset),
+      () => TextFile.withCharset(sqlContext.sparkContext, path, charset, minPartitions),
       Some(path),
       headerFlag,
       delimiter,

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -25,7 +25,16 @@ import org.apache.spark.rdd.RDD
 private[csv] object TextFile {
   val DEFAULT_CHARSET = Charset.forName("UTF-8")
 
-  def withCharset(context: SparkContext, location: String, charset: String, minPartitionsParam: Integer = null): RDD[String] = {
+  def withCharset(context: SparkContext, location: String, charset: String): RDD[String] = {
+    withCharset(context, location, charset, null)
+  }
+
+  def withCharset(
+    context: SparkContext,
+    location: String,
+    charset: String,
+    minPartitionsParam: Integer = null
+  ): RDD[String] = {
     val minPartitions: Int = if (minPartitionsParam == null) {
       context.defaultMinPartitions
     } else {

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -25,13 +25,17 @@ import org.apache.spark.rdd.RDD
 private[csv] object TextFile {
   val DEFAULT_CHARSET = Charset.forName("UTF-8")
 
-  def withCharset(context: SparkContext, location: String, charset: String): RDD[String] = {
+  def withCharset(context: SparkContext, location: String, charset: String, minPartitionsParam: Integer = null): RDD[String] = {
+    val minPartitions: Int = if (minPartitionsParam == null) {
+      context.defaultMinPartitions
+    } else {
+      minPartitionsParam
+    }
     if (Charset.forName(charset) == DEFAULT_CHARSET) {
-      context.textFile(location)
+      context.textFile(location, minPartitions)
     } else {
       // can't pass a Charset object here cause its not serializable
-      // TODO: maybe use mapPartitions instead?
-      context.hadoopFile[LongWritable, Text, TextInputFormat](location).map(
+      context.hadoopFile[LongWritable, Text, TextInputFormat](location, minPartitions).map(
         pair => new String(pair._2.getBytes, 0, pair._2.getLength, charset)
       )
     }

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -44,6 +44,7 @@ private[csv] object TextFile {
       context.textFile(location, minPartitions)
     } else {
       // can't pass a Charset object here cause its not serializable
+      // TODO: maybe use mapPartitions instead?
       context.hadoopFile[LongWritable, Text, TextInputFormat](location, minPartitions).map(
         pair => new String(pair._2.getBytes, 0, pair._2.getLength, charset)
       )

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -52,6 +52,7 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
     val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
+    assert(baseRDD.getNumPartitions == sparkContext.defaultMinPartitions)
   }
 
   test("read utf-8 encoded file using charset alias") {
@@ -85,5 +86,12 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
       TextFile.withCharset(sparkContext, carsFile, "frylock").count()
     }
     assert(exception.getMessage.contains("frylock"))
+  }
+
+  test("read file with minPartitions") {
+    val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8, 3)
+    assert(baseRDD.count() === numLines)
+    assert(baseRDD.first().count(_ == ',') == numColumns)
+    assert(baseRDD.getNumPartitions == 3)
   }
 }

--- a/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TextFileSuite.scala
@@ -52,7 +52,7 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
     val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
-    assert(baseRDD.getNumPartitions == sparkContext.defaultMinPartitions)
+    assert(baseRDD.partitions.length == sparkContext.defaultMinPartitions)
   }
 
   test("read utf-8 encoded file using charset alias") {
@@ -92,6 +92,6 @@ class TextFileSuite extends FunSuite with BeforeAndAfterAll {
     val baseRDD = TextFile.withCharset(sparkContext, carsFile, utf8, 3)
     assert(baseRDD.count() === numLines)
     assert(baseRDD.first().count(_ == ',') == numColumns)
-    assert(baseRDD.getNumPartitions == 3)
+    assert(baseRDD.partitions.length == 3)
   }
 }


### PR DESCRIPTION
It's quite expensive to have to reshuffle huge files after reading to partition them better, so this allows passing the minPartitions argument Hadoop/Spark provide to automatically partition the file as needed while reading.
#141 and #186 already request/address this. You don't seem to be in favor of adding this, but without exposing this option (already present in Spark/Hadoop), this can't be done with the same efficiency, I believe.

The other pull request contains a lot of unrelated/-necessary changes, so I'm hoping to reopen this discussion with a cleaner diff.
Let me know what you think.