### PR TITLE
Change a few access modifiers to improve extensibility.

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -28,7 +28,7 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql._
 import org.apache.spark.sql.sources.{PrunedScan, BaseRelation, InsertableRelation, TableScan}
 import org.apache.spark.sql.types._
-import com.databricks.spark.csv.readers.{BulkCsvReader, LineCsvReader}
+import com.databricks.spark.csv.readers.{BulkCsvReader, LineCsvReader, BulkReader, LineReader}
 import com.databricks.spark.csv.util._
 
 case class CsvRelation protected[spark] (
@@ -213,19 +213,24 @@ case class CsvRelation protected[spark] (
     }
   }
 
-  protected def inferSchema(): StructType = {
+  protected def getLineReader(): LineReader = {
+    val escapeVal = if (escape == null) '\\' else escape.charValue()
+    val commentChar: Char = if (comment == null) '\0' else comment
+    val quoteChar: Char = if (quote == null) '\0' else quote
+
+    new LineCsvReader(
+      fieldSep = delimiter,
+      quote = quoteChar,
+      escape = escapeVal,
+      commentMarker = commentChar)
+  }
+
+  private def inferSchema(): StructType = {
     if (this.userSchema != null) {
       userSchema
     } else {
       val firstRow = if (ParserLibs.isUnivocityLib(parserLib)) {
-        val escapeVal = if (escape == null) '\\' else escape.charValue()
-        val commentChar: Char = if (comment == null) '\0' else comment
-        val quoteChar: Char = if (quote == null) '\0' else quote
-        new LineCsvReader(
-          fieldSep = delimiter,
-          quote = quoteChar,
-          escape = escapeVal,
-          commentMarker = commentChar).parseLine(firstLine)
+        getLineReader().parseLine(firstLine)
       } else {
         val csvFormat = defaultCsvFormat
           .withDelimiter(delimiter)
@@ -265,7 +270,19 @@ case class CsvRelation protected[spark] (
     }
   }
 
-  protected def univocityParseCSV(
+  protected def getBulkReader(
+     header: Seq[String],
+     iter: Iterator[String], split: Int): BulkReader = {
+    val escapeVal = if (escape == null) '\\' else escape.charValue()
+    val commentChar: Char = if (comment == null) '\0' else comment
+    val quoteChar: Char = if (quote == null) '\0' else quote
+
+    new BulkCsvReader(iter, split,
+      headers = header, fieldSep = delimiter,
+      quote = quoteChar, escape = escapeVal, commentMarker = commentChar)
+  }
+
+  private def univocityParseCSV(
      file: RDD[String],
      header: Seq[String]): RDD[Array[String]] = {
     // If header is set, make sure firstLine is materialized before sending to executors.
@@ -273,13 +290,7 @@ case class CsvRelation protected[spark] (
     val dataLines = if (useHeader) file.filter(_ != filterLine) else file
     val rows = dataLines.mapPartitionsWithIndex({
       case (split, iter) => {
-        val escapeVal = if (escape == null) '\\' else escape.charValue()
-        val commentChar: Char = if (comment == null) '\0' else comment
-        val quoteChar: Char = if (quote == null) '\0' else quote
-
-        new BulkCsvReader(iter, split,
-          headers = header, fieldSep = delimiter,
-          quote = quoteChar, escape = escapeVal, commentMarker = commentChar)
+        getBulkReader(header, iter, split)
       }
     }, true)
 

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -213,7 +213,7 @@ case class CsvRelation protected[spark] (
     }
   }
 
-  private def inferSchema(): StructType = {
+  protected def inferSchema(): StructType = {
     if (this.userSchema != null) {
       userSchema
     } else {
@@ -265,7 +265,7 @@ case class CsvRelation protected[spark] (
     }
   }
 
-  private def univocityParseCSV(
+  protected def univocityParseCSV(
      file: RDD[String],
      header: Seq[String]): RDD[Array[String]] = {
     // If header is set, make sure firstLine is materialized before sending to executors.

--- a/src/main/scala/com/databricks/spark/csv/readers/readers.scala
+++ b/src/main/scala/com/databricks/spark/csv/readers/readers.scala
@@ -187,7 +187,7 @@ private[csv] class BulkCsvReader(
  * parsed and needs the newlines to be present
  * @param iter iterator over RDD[String]
  */
-private class StringIteratorReader(val iter: Iterator[String]) extends java.io.Reader {
+private[readers] class StringIteratorReader(val iter: Iterator[String]) extends java.io.Reader {
 
   private var next: Long = 0
   private var length: Long = 0  // length of input so far

--- a/src/main/scala/com/databricks/spark/csv/readers/readers.scala
+++ b/src/main/scala/com/databricks/spark/csv/readers/readers.scala
@@ -22,18 +22,12 @@ import java.io.StringReader
 
 import com.univocity.parsers.csv._
 
-/**
-  * Allows for greater extensibility
-  */
 trait BulkReader extends Iterator[Array[String]] {
-  protected def getReader(iter: Iterator[String]) = new StringIteratorReader(iter)
+  protected def reader(iter: Iterator[String]) = new StringIteratorReader(iter)
 }
 
-/**
- * Allows for greater extensibility
- */
 trait LineReader {
-  protected def getReader(line: String) = new StringReader(line)
+  protected def reader(line: String) = new StringReader(line)
   def parseLine(line: String): Array[String]
 }
 
@@ -120,7 +114,7 @@ private[csv] class LineCsvReader(
    * @return array of strings where each string is a field in the CSV record
    */
   def parseLine(line: String): Array[String] = {
-    parser.beginParsing(getReader(line))
+    parser.beginParsing(reader(line))
     val parsed = parser.parseNext()
     parser.stopParsing()
     parsed
@@ -166,7 +160,7 @@ private[csv] class BulkCsvReader(
     maxCols)
   with BulkReader {
 
-  parser.beginParsing(getReader(iter))
+  parser.beginParsing(reader(iter))
   private var nextRecord = parser.parseNext()
 
   /**
@@ -193,7 +187,7 @@ private[csv] class BulkCsvReader(
  * parsed and needs the newlines to be present
  * @param iter iterator over RDD[String]
  */
-private[readers] class StringIteratorReader(val iter: Iterator[String]) extends java.io.Reader {
+private class StringIteratorReader(val iter: Iterator[String]) extends java.io.Reader {
 
   private var next: Long = 0
   private var length: Long = 0  // length of input so far

--- a/src/main/scala/com/databricks/spark/csv/readers/readers.scala
+++ b/src/main/scala/com/databricks/spark/csv/readers/readers.scala
@@ -178,7 +178,7 @@ private[csv] class BulkCsvReader(
  * parsed and needs the newlines to be present
  * @param iter iterator over RDD[String]
  */
-private class StringIteratorReader(val iter: Iterator[String]) extends java.io.Reader {
+class StringIteratorReader(val iter: Iterator[String]) extends java.io.Reader {
 
   private var next: Long = 0
   private var length: Long = 0  // length of input so far

--- a/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TextFile.scala
@@ -22,7 +22,7 @@ import org.apache.hadoop.mapred.TextInputFormat
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 
-private[csv] object TextFile {
+object TextFile {
   val DEFAULT_CHARSET = Charset.forName("UTF-8")
 
   def withCharset(context: SparkContext, location: String, charset: String): RDD[String] = {


### PR DESCRIPTION
Currently a lot of functionality is hidden behind private access modifiers making it difficult to extend the functionality of the library without copying large chunks of code. These small changes make re-use much easier.

The specific use case I have is parsing fixed-width text files. The univosity parser library (used by spark-csv) actually supports this, but spark-csv itself does not. Rather than rewriting a good chunk of the existing library I opted to extend it by adding a new entry point and swapping-out the parsers. To do this, I had to make a few methods and classes in spark-csv more accessible. Hopefully this also makes extensibility in general easier, so parsers for other file types can be more easily created. 

Also, If there's general interest in flat-file parsing then I'm happy to incorporate that directly into spark-csv.