### PR TITLE
Adding and option to the csv parser, withParseExecptionAsNull which a…

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvParser.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvParser.scala
@@ -42,6 +42,7 @@ class CsvParser extends Serializable {
   private var codec: String = null
   private var nullValue: String = ""
   private var dateFormat: String = null
+  private var treatParseExceptionAsNull : Boolean = false
 
   def withUseHeader(flag: Boolean): CsvParser = {
     this.useHeader = flag
@@ -123,6 +124,16 @@ class CsvParser extends Serializable {
     this
   }
 
+  /**
+    * If this is set to true then dirty data, for example a string in a numeric column,
+    * or a mal-formed date will not cause a failure.
+    * Instead, that value will be null in the resulting data
+    */
+  def withTreatParseExceptionAsNull(flag : Boolean) : CsvParser = {
+    this.treatParseExceptionAsNull = flag
+    this
+  }
+
   /** Returns a Schema RDD for the given CSV path. */
   @throws[RuntimeException]
   def csvFile(sqlContext: SQLContext, path: String): DataFrame = {
@@ -143,7 +154,8 @@ class CsvParser extends Serializable {
       inferSchema,
       codec,
       nullValue,
-      dateFormat)(sqlContext)
+      dateFormat,
+      treatParseExceptionAsNull)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 
@@ -165,7 +177,8 @@ class CsvParser extends Serializable {
       inferSchema,
       codec,
       nullValue,
-      dateFormat)(sqlContext)
+      dateFormat,
+      treatParseExceptionAsNull)(sqlContext)
     sqlContext.baseRelationToDataFrame(relation)
   }
 }

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -49,7 +49,9 @@ case class CsvRelation protected[spark] (
     inferCsvSchema: Boolean,
     codec: String = null,
     nullValue: String = "",
-    dateFormat: String = null)(@transient val sqlContext: SQLContext)
+    dateFormat: String = null,
+    treatParseExceptionAsNull: Boolean)
+  (@transient val sqlContext: SQLContext)
   extends BaseRelation with TableScan with PrunedScan with InsertableRelation {
 
   // Share date format object as it is expensive to parse date pattern.
@@ -118,7 +120,8 @@ case class CsvRelation protected[spark] (
           while (index < schemaFields.length) {
             val field = schemaFields(index)
             rowArray(index) = TypeCast.castTo(tokens(index), field.dataType, field.nullable,
-              treatEmptyValuesAsNulls, nullValue, simpleDateFormatter)
+              treatEmptyValuesAsNulls, nullValue, simpleDateFormatter,
+              treatParseExceptionAsNull)
             index = index + 1
           }
           Some(Row.fromSeq(rowArray))
@@ -197,7 +200,8 @@ case class CsvRelation protected[spark] (
                 field.nullable,
                 treatEmptyValuesAsNulls,
                 nullValue,
-                simpleDateFormatter
+                simpleDateFormatter,
+                treatParseExceptionAsNull
               )
               subIndex = subIndex + 1
             }

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -125,6 +125,16 @@ class DefaultSource
       throw new Exception("Treat empty values as null flag can be true or false")
     }
 
+    val treatParseExceptionAsNull = parameters.getOrElse(
+      "treatParseExceptionAsNull", "false")
+    val treatParseExceptionAsNullFlag = if (treatParseExceptionAsNull == "false"){
+      false
+    } else if (treatParseExceptionAsNull == "true") {
+      true
+    } else {
+      throw new Exception("Treat parse exception as null flag can be true or false")
+    }
+
     val charset = parameters.getOrElse("charset", TextFile.DEFAULT_CHARSET.name())
     // TODO validate charset?
 
@@ -159,7 +169,8 @@ class DefaultSource
       inferSchemaFlag,
       codec,
       nullValue,
-      dateFormat)(sqlContext)
+      dateFormat,
+      treatParseExceptionAsNullFlag)(sqlContext)
   }
 
   override def createRelation(

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -56,7 +56,8 @@ package object csv {
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
         treatEmptyValuesAsNulls = false,
-        inferCsvSchema = inferSchema)(sqlContext)
+        inferCsvSchema = inferSchema,
+        treatParseExceptionAsNull = false)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
 
@@ -81,7 +82,8 @@ package object csv {
         ignoreLeadingWhiteSpace = ignoreLeadingWhiteSpace,
         ignoreTrailingWhiteSpace = ignoreTrailingWhiteSpace,
         treatEmptyValuesAsNulls = false,
-        inferCsvSchema = inferSchema)(sqlContext)
+        inferCsvSchema = inferSchema,
+        treatParseExceptionAsNull = false)(sqlContext)
       sqlContext.baseRelationToDataFrame(csvRelation)
     }
   }

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -64,9 +64,11 @@ object TypeCast {
           case _: IntegerType => datum.toInt
           case _: LongType => datum.toLong
           case _: FloatType => Try(datum.toFloat)
-                               .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
+                               .getOrElse(NumberFormat
+                                          .getInstance(Locale.getDefault).parse(datum).floatValue())
           case _: DoubleType => Try(datum.toDouble)
-                                .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
+                                .getOrElse(NumberFormat.getInstance(Locale.getDefault)
+                                           .parse(datum).doubleValue())
           case _: BooleanType => datum.toBoolean
           case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
           case _: TimestampType if dateFormatter != null =>

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -21,6 +21,7 @@ import java.text.{SimpleDateFormat, NumberFormat}
 import java.util.Locale
 
 import org.apache.spark.sql.types._
+import org.json4s.ParserUtil.ParseException
 
 import scala.util.Try
 
@@ -45,7 +46,8 @@ object TypeCast {
       nullable: Boolean = true,
       treatEmptyValuesAsNulls: Boolean = false,
       nullValue: String = "",
-      dateFormatter: SimpleDateFormat = null): Any = {
+      dateFormatter: SimpleDateFormat = null,
+      parseExceptionAsNull : Boolean = false): Any = {
     // if nullValue is not an empty string, don't require treatEmptyValuesAsNulls
     // to be set to true
     val nullValueIsNotEmpty = nullValue != ""
@@ -55,25 +57,32 @@ object TypeCast {
       ){
       null
     } else {
-      castType match {
-        case _: ByteType => datum.toByte
-        case _: ShortType => datum.toShort
-        case _: IntegerType => datum.toInt
-        case _: LongType => datum.toLong
-        case _: FloatType => Try(datum.toFloat)
-          .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
-        case _: DoubleType => Try(datum.toDouble)
-          .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
-        case _: BooleanType => datum.toBoolean
-        case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
-        case _: TimestampType if dateFormatter != null =>
-          new Timestamp(dateFormatter.parse(datum).getTime)
-        case _: TimestampType => Timestamp.valueOf(datum)
-        case _: DateType if dateFormatter != null =>
-          new Date(dateFormatter.parse(datum).getTime)
-        case _: DateType => Date.valueOf(datum)
-        case _: StringType => datum
-        case _ => throw new RuntimeException(s"Unsupported type: ${castType.typeName}")
+      try {
+        castType match {
+          case _: ByteType => datum.toByte
+          case _: ShortType => datum.toShort
+          case _: IntegerType => datum.toInt
+          case _: LongType => datum.toLong
+          case _: FloatType => Try(datum.toFloat)
+                               .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).floatValue())
+          case _: DoubleType => Try(datum.toDouble)
+                                .getOrElse(NumberFormat.getInstance(Locale.getDefault).parse(datum).doubleValue())
+          case _: BooleanType => datum.toBoolean
+          case _: DecimalType => new BigDecimal(datum.replaceAll(",", ""))
+          case _: TimestampType if dateFormatter != null =>
+            new Timestamp(dateFormatter.parse(datum).getTime)
+          case _: TimestampType => Timestamp.valueOf(datum)
+          case _: DateType if dateFormatter != null =>
+            new Date(dateFormatter.parse(datum).getTime)
+          case _: DateType => Date.valueOf(datum)
+          case _: StringType => datum
+          case _ => throw new UnsupportedTypeException(s"Unsupported type: ${castType.typeName}")
+        }
+      }
+      catch {
+        case e : UnsupportedTypeException =>
+          throw e
+       case e => if (parseExceptionAsNull && nullable) null else throw e
       }
     }
   }
@@ -106,3 +115,6 @@ object TypeCast {
     }
   }
 }
+
+class UnsupportedTypeException(message: String = null, cause: Throwable = null)
+  extends RuntimeException(message, cause)

--- a/src/test/resources/cars_dirty.csv
+++ b/src/test/resources/cars_dirty.csv
@@ -1,0 +1,5 @@
+year,make,model,price,comment,blank
+2012,Tesla,S"80,000.65"
+2013.5,Ford,E350,35,000,"Go get one now they are going fast"
+2015,,Volt,5,000
+new,"",Volt,5000.00

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -24,6 +24,8 @@ import org.scalatest.FunSuite
 
 import org.apache.spark.sql.types._
 
+import scala.util.Try
+
 class TypeCastSuite extends FunSuite {
 
   test("Can parse decimal type values") {
@@ -115,4 +117,48 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("", StringType, true, false, "") == "")
     assert(TypeCast.castTo("", StringType, true, true, "") == null)
   }
+
+  test("Parse exception is caught correctly"){
+
+    def testParseException( castType : DataType, badValues : Seq[String]): Unit = {
+      badValues.foreach(testValue => {
+        assert(TypeCast.castTo(testValue, castType, true, false, "", null, true) == null)
+        // if not nullable it isn't null
+        assert(Try(TypeCast.castTo(testValue, castType, false, false, "", null, true)).isFailure)
+      }
+      )
+    }
+
+    assert(TypeCast.castTo("10", ByteType, true, false, "", null, true) == 10)
+    testParseException(ByteType, Seq("10.5", "s", "true"))
+
+    assert(TypeCast.castTo("10", ShortType, true, false, "", null, true) == 10)
+    testParseException(ShortType, Seq("s", "true"))
+
+    assert(TypeCast.castTo("10", IntegerType, true, false, "", null, true) == 10)
+    testParseException(IntegerType, Seq("10.5", "s", "true"))
+
+    assert(TypeCast.castTo("10", LongType, true, false, "", null, true) == 10)
+    testParseException(LongType, Seq("10.5", "s", "true"))
+
+    assert(TypeCast.castTo("1.00", FloatType, true, false, "", null, true) == 1.0)
+    testParseException(FloatType, Seq("s", "true"))
+
+    assert(TypeCast.castTo("1.00", DoubleType, true, false, "", null, true) == 1.0)
+    testParseException(DoubleType, Seq("s", "true"))
+
+    assert(TypeCast.castTo("true", BooleanType, true, false, "", null, true) == true)
+    testParseException(BooleanType, Seq("s", "5"))
+
+    val timestamp = "2015-01-01 00:00:00"
+    assert(TypeCast.castTo(timestamp, TimestampType, true, false, "", null, true)
+      == Timestamp.valueOf(timestamp))
+    testParseException(TimestampType, Seq("5", "string"))
+
+    assert(TypeCast.castTo("2015-01-01", DateType, true, false, "", null, true)
+      == Date.valueOf("2015-01-01"))
+    testParseException(DateType, Seq("5", "string", timestamp))
+  }
+
+
 }


### PR DESCRIPTION
…llows dirty data to be parsed as nulls rather than cause failures. For example, if there is a String in a numeric column, rather than failing it lets that value be null. My experience is that data is often dirty, and some times you want and option that allows mall-formed numbers or dates without causing failures. I have notice a good deal of issues related to this package have to do with similar problems. My implementation is written so that it doesn't affect any of the existing functionality. Instead, it provides an extra option "withParseExceptionAsNull".
