### PR TITLE
Add the support for ignoreTrailingWhiteSpace and ignoreLeadingWhiteSpace

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The package also supports saving simple (non-nested) DataFrame. When writing fil
 * `nullValue`: specificy a string that indicates a null value, nulls in the DataFrame will be written as this string.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 * `quoteMode`: when to quote fields (`ALL`, `MINIMAL` (default), `NON_NUMERIC`, `NONE`), see [Quote Modes](https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/QuoteMode.html)
+* `ignoreLeadingWhiteSpace`:  when set to true, it ignores leading white spaces. This option is only supported for "univocity" `parseLib` but "common" `parseLib` supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. This option is only supported for "univocity" `parseLib` but "common" `parseLib` supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
 
 These examples use a CSV file available for download [here](https://github.com/databricks/spark-csv/raw/master/src/test/resources/cars.csv):
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ When reading files the API accepts several options:
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
 * `dateFormat`: specificy a string that indicates a date format. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`.
+* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. This option is supported for "univocity" `parseLib` but "common" `parseLib` also supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. This option is supported for "univocity" `parseLib` but "common" `parseLib` supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
 
 The package also supports saving simple (non-nested) DataFrame. When writing files the API accepts several options:
 * `path`: location of files.
@@ -67,8 +69,6 @@ The package also supports saving simple (non-nested) DataFrame. When writing fil
 * `nullValue`: specificy a string that indicates a null value, nulls in the DataFrame will be written as this string.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 * `quoteMode`: when to quote fields (`ALL`, `MINIMAL` (default), `NON_NUMERIC`, `NONE`), see [Quote Modes](https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/QuoteMode.html)
-* `ignoreLeadingWhiteSpace`:  when set to true, it ignores leading white spaces. This option is only supported for "univocity" `parseLib` but "common" `parseLib` supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
-* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. This option is only supported for "univocity" `parseLib` but "common" `parseLib` supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
 
 These examples use a CSV file available for download [here](https://github.com/databricks/spark-csv/raw/master/src/test/resources/cars.csv):
 

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ When reading files the API accepts several options:
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
 * `dateFormat`: specificy a string that indicates a date format. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`.
-* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. This option is supported for "univocity" `parseLib` but for "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
-* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. This option is supported for "univocity" `parseLib` but for "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. For "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. For "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
 
 The package also supports saving simple (non-nested) DataFrame. When writing files the API accepts several options:
 * `path`: location of files.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ When reading files the API accepts several options:
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
 * `dateFormat`: specificy a string that indicates a date format. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`.
-* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. For "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
-* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. For "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. For "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true. Default value is false.
+* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. For "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true. Default value is false.
 
 The package also supports saving simple (non-nested) DataFrame. When writing files the API accepts several options:
 * `path`: location of files.

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ When reading files the API accepts several options:
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
 * `dateFormat`: specificy a string that indicates a date format. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`.
-* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. This option is supported for "univocity" `parseLib` but "common" `parseLib` also supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
-* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. This option is supported for "univocity" `parseLib` but "common" `parseLib` supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreLeadingWhiteSpace`: when set to true, it ignores leading white spaces. This option is supported for "univocity" `parseLib` but for "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
+* `ignoreTrailingWhiteSpace`: when set to true, it ignores trailing white spaces. This option is supported for "univocity" `parseLib` but for "common" `parseLib`, it only supports this when both `ignoreLeadingWhiteSpace` and `ignoreTrailingWhiteSpace` are set to true.
 
 The package also supports saving simple (non-nested) DataFrame. When writing files the API accepts several options:
 * `path`: location of files.

--- a/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
+++ b/src/main/scala/com/databricks/spark/csv/DefaultSource.scala
@@ -94,28 +94,31 @@ class DefaultSource
     }
 
     val parserLib = parameters.getOrElse("parserLib", ParserLibs.DEFAULT)
+
     val ignoreLeadingWhiteSpace = parameters.getOrElse("ignoreLeadingWhiteSpace", "false")
     val ignoreLeadingWhiteSpaceFlag = if (ignoreLeadingWhiteSpace == "false") {
       false
     } else if (ignoreLeadingWhiteSpace == "true") {
-      if (!ParserLibs.isUnivocityLib(parserLib)) {
-        throw new Exception("Ignore whitesspace supported for Univocity parser only")
-      }
       true
     } else {
       throw new Exception("Ignore white space flag can be true or false")
     }
+
     val ignoreTrailingWhiteSpace = parameters.getOrElse("ignoreTrailingWhiteSpace", "false")
     val ignoreTrailingWhiteSpaceFlag = if (ignoreTrailingWhiteSpace == "false") {
       false
     } else if (ignoreTrailingWhiteSpace == "true") {
-      if (!ParserLibs.isUnivocityLib(parserLib)) {
-        throw new Exception("Ignore whitespace supported for the Univocity parser only")
-      }
       true
     } else {
       throw new Exception("Ignore white space flag can be true or false")
     }
+
+    if ((ignoreLeadingWhiteSpaceFlag != ignoreTrailingWhiteSpaceFlag) &&
+        !ParserLibs.isUnivocityLib(parserLib)) {
+      throw new Exception("Ignoring either leading or trailing whitespaces " +
+        "is only supported for the Univocity parser.")
+    }
+
     val treatEmptyValuesAsNulls = parameters.getOrElse("treatEmptyValuesAsNulls", "false")
     val treatEmptyValuesAsNullsFlag = if (treatEmptyValuesAsNulls == "false") {
       false

--- a/src/test/resources/cars-whitespaces.csv
+++ b/src/test/resources/cars-whitespaces.csv
@@ -1,0 +1,9 @@
+~ `year` field has leading whitespaces
+~ `make` field has trailing whitespaces
+~ `model` and `comment` fields have leading and trailing whitespaces
+year,make,model,comment,blank
+ "2012","Tesla"  , "S" ,  "No comment"  ,
+
+  1997,Ford ,  E350 , "Go get one now they are going fast" ,
+ 2015,Chevy   , Volt
+

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -48,7 +48,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
   private val boolFile = "src/test/resources/bool.csv"
   private val datesFile = "src/test/resources/dates.csv"
   private val simpleDatasetFile = "src/test/resources/simple.csv"
-  private val carsWhitespaces = "src/test/resources/cars-whitespaces.csv"
+  private val carsWhitespacesFile = "src/test/resources/cars-whitespaces.csv"
 
   val numCars = 3
 
@@ -250,7 +250,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       .withIgnoreLeadingWhiteSpace(true)
       .withIgnoreTrailingWhiteSpace(true)
       .withParserLib(parserLib)
-      .csvFile(sqlContext, carsWhitespaces)
+      .csvFile(sqlContext, carsWhitespacesFile)
     val expectedSchema = StructType(List(
       StructField("year", IntegerType, nullable = true),
       StructField("make", StringType, nullable = true),
@@ -280,7 +280,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       .withTreatEmptyValuesAsNulls(true)
       .withIgnoreLeadingWhiteSpace(true)
       .withParserLib(parserLib)
-      .csvFile(sqlContext, carsWhitespaces)
+      .csvFile(sqlContext, carsWhitespacesFile)
     val maybeYearField = cars.schema.fields.find(_.name == "year")
     assert(maybeYearField.isDefined)
     // If the leading spaces were trimmed then it should be inferred as `IntegerType`.
@@ -303,7 +303,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
       .withTreatEmptyValuesAsNulls(true)
       .withIgnoreTrailingWhiteSpace(true)
       .withParserLib(parserLib)
-      .csvFile(sqlContext, carsWhitespaces)
+      .csvFile(sqlContext, carsWhitespacesFile)
     // If the leading spaces were not trimmed then it should be inferred as `StringType`.
     val maybeYearField = cars.schema.fields.find(_.name == "year")
     assert(maybeYearField.isDefined)

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -270,8 +270,8 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
   }
 
   test("DSL test ignoreLeadingWhiteSpace option") {
-    assume(parserLib == "UNIVOCITY", "Setting ignoreTrailingWhiteSpace true and " +
-      "ignoreLeadingWhiteSpace to false is only supported for Univocity parser ")
+    assume(parserLib == "UNIVOCITY", "Setting ignoreTrailingWhiteSpace false and " +
+      "ignoreLeadingWhiteSpace to true is only supported for Univocity parser ")
     // Test leading white spaces.
     val cars = new CsvParser()
       .withUseHeader(true)

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -292,7 +292,7 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
     }
   }
 
-  test("DSL test either ignoreTrailingWhiteSpace option") {
+  test("DSL test ignoreTrailingWhiteSpace option") {
     assume(parserLib == "UNIVOCITY", "Setting ignoreTrailingWhiteSpace true and " +
       "ignoreLeadingWhiteSpace to false is only supported for Univocity parser ")
     // Test leading white spaces.


### PR DESCRIPTION
https://github.com/databricks/spark-csv/issues/304

This PR adds the support for `ignoreTrailingWhiteSpace` and `ignoreLeadingWhiteSpace` options which were exposed but not implemented.

For Apache Common CSV Parser (`common`),  it supports the functionalities only when both `ignoreTrailingWhiteSpace` and `ignoreLeadingWhiteSpace` are set to `true` by using `withIgnoreSurroundingSpaces()` at `CSVFormat`.

For Univocity parser (`univocity`),  it supports this functionalities for `ignoreTrailingWhiteSpace`, and/or `ignoreLeadingWhiteSpace` by using `setIgnoreLeadingWhitespaces()` and/or `setIgnoreTrailingWhitespaces()` at `CsvParserSettings`.
