### PR TITLE
Fix for #308 write using specified dateFormat

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ When reading files the API accepts several options:
 * `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
 * `nullValue`: specifies a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
-* `dateFormat`: specifies a string that indicates a date format to use when reading or writing dates or timestamps. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`. If no dateFormat is specified, then "yyyy-MM-dd HH:mm:ss.S" is used for writing.
+* `dateFormat`: specifies a string that indicates the date format to use when reading dates or timestamps. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`.
 
 The package also supports saving simple (non-nested) DataFrame. When writing files the API accepts several options:
 * `path`: location of files.
@@ -65,6 +65,7 @@ The package also supports saving simple (non-nested) DataFrame. When writing fil
 * `quote`: by default the quote character is `"`, but can be set to any character. This is written according to `quoteMode`.
 * `escape`: by default the escape character is `\`, but can be set to any character. Escaped quote characters are written.
 * `nullValue`: specifies a string that indicates a null value, nulls in the DataFrame will be written as this string.
+* `dateFormat`: specifies a string that indicates the date format to use writing dates or timestamps. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. If no dateFormat is specified, then "yyyy-MM-dd HH:mm:ss.S".
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 * `quoteMode`: when to quote fields (`ALL`, `MINIMAL` (default), `NON_NUMERIC`, `NONE`), see [Quote Modes](https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/QuoteMode.html)
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ When reading files the API accepts several options:
 * `charset`: defaults to 'UTF-8' but can be set to other valid charset names
 * `inferSchema`: automatically infers column types. It requires one extra pass over the data and is false by default
 * `comment`: skip lines beginning with this character. Default is `"#"`. Disable comments by setting this to `null`.
-* `nullValue`: specificy a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
-* `dateFormat`: specificy a string that indicates a date format. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`.
+* `nullValue`: specifies a string that indicates a null value, any fields matching this string will be set as nulls in the DataFrame
+* `dateFormat`: specifies a string that indicates a date format to use when reading or writing dates or timestamps. Custom date formats follow the formats at [`java.text.SimpleDateFormat`](https://docs.oracle.com/javase/7/docs/api/java/text/SimpleDateFormat.html). This applies to both `DateType` and `TimestampType`. By default, it is `null` which means trying to parse times and date by `java.sql.Timestamp.valueOf()` and `java.sql.Date.valueOf()`. If no dateFormat is specified, then "yyyy-MM-dd HH:mm:ss.S" is used for writing.
 
 The package also supports saving simple (non-nested) DataFrame. When writing files the API accepts several options:
 * `path`: location of files.
@@ -64,7 +64,7 @@ The package also supports saving simple (non-nested) DataFrame. When writing fil
 * `delimiter`: by default columns are delimited using `,`, but delimiter can be set to any character
 * `quote`: by default the quote character is `"`, but can be set to any character. This is written according to `quoteMode`.
 * `escape`: by default the escape character is `\`, but can be set to any character. Escaped quote characters are written.
-* `nullValue`: specificy a string that indicates a null value, nulls in the DataFrame will be written as this string.
+* `nullValue`: specifies a string that indicates a null value, nulls in the DataFrame will be written as this string.
 * `codec`: compression codec to use when saving to file. Should be the fully qualified name of a class implementing `org.apache.hadoop.io.compress.CompressionCodec` or one of case-insensitive shorten names (`bzip2`, `gzip`, `lz4`, and `snappy`). Defaults to no compression when a codec is not specified.
 * `quoteMode`: when to quote fields (`ALL`, `MINIMAL` (default), `NON_NUMERIC`, `NONE`), see [Quote Modes](https://commons.apache.org/proper/commons-csv/apidocs/org/apache/commons/csv/QuoteMode.html)
 

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -154,10 +154,12 @@ package object csv {
         "" // There is no need to generate header in this case
       }
 
-      // Create an index for the format by type so the type check does not have to happen in the inner loop.
+      // Create an index for the format by type so the type check
+      // does not have to happen in the inner loop.
       val schema = dataFrame.schema
       val formatForIdx = schema.fieldNames.map(fname => schema(fname).dataType match {
-        case TimestampType => (timestamp: Any) => dateFormatter.format(new Date(timestamp.asInstanceOf[Timestamp].getTime))
+        case TimestampType => (timestamp: Any) =>
+          dateFormatter.format(new Date(timestamp.asInstanceOf[Timestamp].getTime))
         case DateType => (date: Any) => dateFormatter.format(date)
         case _ => (fieldValue: Any) => fieldValue.asInstanceOf[AnyRef]
       })

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -171,14 +171,8 @@ package object csv {
             if (iter.nonEmpty) {
               val values: Seq[AnyRef] = iter.next().toSeq.map(
                 fieldValue => fieldValue match {
-                  case timestamp: Timestamp => {
-                    println("date = " + timestamp.toString + " pat = " + dateFormatter.toPattern)
-                    dateFormatter.format(new Date(timestamp.getTime))
-                  }
-                  case date: Date => {
-                    println("date = " + date.toString + " pat = " + dateFormatter.toPattern)
-                    dateFormatter.format(date)
-                  }
+                  case timestamp: Timestamp => dateFormatter.format(new Date(timestamp.getTime))
+                  case date: Date => dateFormatter.format(date)
                   case _ => fieldValue.asInstanceOf[AnyRef]
                 })
               println(values.mkString(", "))

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -100,7 +100,8 @@ package object csv {
                       compressionCodec: Class[_ <: CompressionCodec] = null): Unit = {
       // TODO(hossein): For nested types, we may want to perform special work
       val delimiter = parameters.getOrElse("delimiter", ",")
-      // Before this change the csvFormatter wrot dates like this: "2014-11-15 06:31:10.0" so have that as the default.
+      // Before this change the csvFormatter wrote dates like this:
+      // "2014-11-15 06:31:10.0", so have that as the default.
       val dateFormat = parameters.getOrElse("dateFormat", "yyyy-MM-dd HH:mm:ss.S")
       val dateFormatter: SimpleDateFormat = new SimpleDateFormat(dateFormat)
 
@@ -167,7 +168,6 @@ package object csv {
           override def hasNext: Boolean = iter.hasNext || firstRow
 
           override def next: String = {
-            
             if (iter.nonEmpty) {
               val values: Seq[AnyRef] = iter.next().toSeq.map(
                 fieldValue => fieldValue match {

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -175,7 +175,6 @@ package object csv {
                   case date: Date => dateFormatter.format(date)
                   case _ => fieldValue.asInstanceOf[AnyRef]
                 })
-              println(values.mkString(", "))
               val row = csvFormat.format(values: _*)
               if (firstRow) {
                 firstRow = false

--- a/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
@@ -54,13 +54,8 @@ class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "dates-copy.csv"
     val retDataFile = tempEmptyDir + "dates-result.csv"
 
-    // Write dataframe this way prior in spark 1.3 and before
+    // Write dataframe this way prior in spark 1.3 and before (later versions use dates.write.format)
     dates.saveAsCsvFile(copyFilePath, Map("header" -> "false"))
-
-    // This method of writing can be used after spark 1.3
-    // dates.write.format("com.databricks.spark.csv")
-    //   .option("header", "false")
-    //   .save(copyFilePath)
 
     FileUtil.fullyDelete(new File(retDataFile))
     merge(copyFilePath, retDataFile)
@@ -82,12 +77,6 @@ class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
     // Write dataframe this way prior in spark 1.3 and before
     dates.saveAsCsvFile(copyFilePath,
       Map("header" -> "false", "dateFormat" -> "MM/dd/yyyy HH:mm:ss"))
-
-    // This method of writing can be used after spark 1.3
-    // dates.write.format("com.databricks.spark.csv")
-    //   .option("header", "false")
-    //   .option("dateFormat", "MM/dd/yyyy HH:mm:ss")
-    //   .save(copyFilePath)
 
     FileUtil.fullyDelete(new File(retDataFile))
     merge(copyFilePath, retDataFile)

--- a/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
@@ -54,7 +54,8 @@ abstract class AbstractCsvWriteSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "dates-copy.csv"
     val retDataFile = tempEmptyDir + "dates-result.csv"
 
-    // Write dataframe this way prior in spark 1.3 and before (later versions use dates.write.format)
+    // Write dataframe this way prior in spark 1.3 and before
+    // (later versions use dates.write.format)
     dates.saveAsCsvFile(copyFilePath, Map("header" -> "false"))
 
     FileUtil.fullyDelete(new File(retDataFile))

--- a/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2014 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.databricks.spark.csv
+
+import java.io.File
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, FileUtil, Path}
+import org.apache.spark.SparkContext
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, SQLContext}
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+import scala.io.Source
+
+class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
+
+  val datesFile = "src/test/resources/dates.csv"
+  val tempEmptyDir = "target/test/empty/"
+
+  def parserLib: String = "COMMONS"
+
+  private var sqlContext: SQLContext = _
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    sqlContext = new SQLContext(new SparkContext("local[2]", "CsvWriteSuite"))
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      sqlContext.sparkContext.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+
+  test("Save with default date format") {
+    mkTempDir()
+    val dates = readDatesFromFile()
+    val copyFilePath = tempEmptyDir + "dates-copy.csv"
+    val retDataFile = tempEmptyDir + "dates-result.csv"
+
+    dates.write.format("com.databricks.spark.csv")
+      .option("header", "false")
+      .save(copyFilePath)
+    FileUtil.fullyDelete(new File(retDataFile))
+    merge(copyFilePath, retDataFile)
+
+    val actualContents = readFile(retDataFile)
+
+    assert("2015-08-26 18:00:00.0\n2014-10-27 18:30:00.0\n2016-01-28 20:00:00.0" === actualContents)
+  }
+
+
+  test("Save with custom date format") {
+    mkTempDir()
+    val dates = readDatesFromFile()
+    dates.show()
+
+    val copyFilePath = tempEmptyDir + "dates-copy.csv"
+    val retDataFile = tempEmptyDir + "dates-result.csv"
+
+    dates.write.format("com.databricks.spark.csv")
+      .option("header", "false")
+      .option("dateFormat", "MM/dd/yyyy HH:mm:ss")
+      .save(copyFilePath)
+
+    FileUtil.fullyDelete(new File(retDataFile))
+    merge(copyFilePath, retDataFile)
+
+    val actualContents = readFile(retDataFile)
+
+    // note that dates have been written with custom format
+    assert("08/26/2015 18:00:00\n10/27/2014 18:30:00\n01/28/2016 20:00:00" === actualContents)
+  }
+
+  // Create temp directory
+  def mkTempDir(): Unit = {
+    TestUtils.deleteRecursively(new File(tempEmptyDir))
+    new File(tempEmptyDir).mkdirs()
+  }
+
+  def readDatesFromFile(): DataFrame = {
+    val customSchema = new StructType(Array(StructField("date", TimestampType, true)))
+    new CsvParser()
+      .withSchema(customSchema)
+      .withUseHeader(true)
+      .withParserLib(parserLib)
+      .withDateFormat("dd/MM/yyyy HH:mm")
+      .csvFile(sqlContext, datesFile)
+      .select("date")
+  }
+
+  def readFile(fname: String): String = {
+    val source = Source.fromFile(fname)
+    try source.getLines.mkString("\n") finally source.close()
+  }
+
+  private def merge(srcPath: String, dstPath: String): Unit = {
+    val hadoopConfig = new Configuration()
+    val hdfs = FileSystem.get(hadoopConfig)
+    FileUtil.copyMerge(hdfs, new Path(srcPath), hdfs, new Path(dstPath), false, hadoopConfig, null)
+  }
+}
+

--- a/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
@@ -54,17 +54,22 @@ class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "dates-copy.csv"
     val retDataFile = tempEmptyDir + "dates-result.csv"
 
-    dates.write.format("com.databricks.spark.csv")
-      .option("header", "false")
-      .save(copyFilePath)
+    // Write dataframe this way prior in spark 1.3 and before
+    dates.saveAsCsvFile(copyFilePath, Map("header" -> "false"))
+
+    // This method of writing can be used after spark 1.3
+    // dates.write.format("com.databricks.spark.csv")
+    //   .option("header", "false")
+    //   .save(copyFilePath)
+
     FileUtil.fullyDelete(new File(retDataFile))
     merge(copyFilePath, retDataFile)
 
     val actualContents = readFile(retDataFile)
 
-    assert("2015-08-26 18:00:00.0\n2014-10-27 18:30:00.0\n2016-01-28 20:00:00.0" === actualContents)
+    assert("2015-08-26 18:00:00.0\n2014-10-27 18:30:00.0\n2016-01-28 20:00:00.0"
+      === actualContents)
   }
-
 
   test("Save with custom date format") {
     mkTempDir()
@@ -74,10 +79,15 @@ class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
     val copyFilePath = tempEmptyDir + "dates-copy.csv"
     val retDataFile = tempEmptyDir + "dates-result.csv"
 
-    dates.write.format("com.databricks.spark.csv")
-      .option("header", "false")
-      .option("dateFormat", "MM/dd/yyyy HH:mm:ss")
-      .save(copyFilePath)
+    // Write dataframe this way prior in spark 1.3 and before
+    dates.saveAsCsvFile(copyFilePath,
+      Map("header" -> "false", "dateFormat" -> "MM/dd/yyyy HH:mm:ss"))
+
+    // This method of writing can be used after spark 1.3
+    // dates.write.format("com.databricks.spark.csv")
+    //   .option("header", "false")
+    //   .option("dateFormat", "MM/dd/yyyy HH:mm:ss")
+    //   .save(copyFilePath)
 
     FileUtil.fullyDelete(new File(retDataFile))
     merge(copyFilePath, retDataFile)

--- a/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvWriteSuite.scala
@@ -26,12 +26,12 @@ import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import scala.io.Source
 
-class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
+abstract class AbstractCsvWriteSuite extends FunSuite with BeforeAndAfterAll {
 
   val datesFile = "src/test/resources/dates.csv"
   val tempEmptyDir = "target/test/empty/"
 
-  def parserLib: String = "COMMONS"
+  def parserLib: String
 
   private var sqlContext: SQLContext = _
 
@@ -69,7 +69,6 @@ class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
   test("Save with custom date format") {
     mkTempDir()
     val dates = readDatesFromFile()
-    dates.show()
 
     val copyFilePath = tempEmptyDir + "dates-copy.csv"
     val retDataFile = tempEmptyDir + "dates-result.csv"
@@ -116,3 +115,11 @@ class CsvWriteSuite extends FunSuite with BeforeAndAfterAll {
   }
 }
 
+
+class CsvWriteSuite extends AbstractCsvWriteSuite {
+  override def parserLib: String = "COMMONS"
+}
+
+class CsvFastWriteSuite extends AbstractCsvWriteSuite {
+  override def parserLib: String = "UNIVOCITY"
+}


### PR DESCRIPTION
Added support for writing to file with dateFormat that is specified in the options.  Added some basic tests for it.

I'm continuing to use SimpleDateFormat since that is what is used for reading. I would prefer joda's DateTimeFormat, but that can be a separate issue.

It's too bad CSVFormat does not allow specification of a dateFormat as it does for the null value. That would make this much easier.