### PR TITLE
only write CSV header on the first partition (#317)

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -155,7 +155,7 @@ package object csv {
           .withNullString(nullValue)
 
         new Iterator[String] {
-          var firstRow: Boolean = generateHeader
+          var firstRow: Boolean = generateHeader && (index==0)
 
           override def hasNext: Boolean = iter.hasNext || firstRow
 


### PR DESCRIPTION
This seems to fix the problem I saw mentioned in #317.  I'm most certainly _not_ saying that this change should go in without someone who knows what they are doing taking a look!

In particular if anyone had been relying on the old behaviour they would get a nasty surprise.  However I think this is a more useful default.