### PR TITLE
Add warning message for incompatibility for Spark 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-**This library does not support Spark 2.0+. This library has been ported into Spark 2.0.**
-
+**This library does not gurantee the compatibility for Spark 2.0+. This library has been ported into Spark 2.0+. Please use the internal CSV datasource in Spark 2.0+.**
 
 # CSV Data Source for Apache Spark
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**This library does not support Spark 2.0+. This library has been ported into Spark 2.0.**
+
+
 # CSV Data Source for Apache Spark
 
 A library for parsing and querying CSV data with Apache Spark, for Spark SQL and DataFrames.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**This library does not gurantee the compatibility for Spark 2.0+. This library has been ported into Spark 2.0+. Please use the internal CSV datasource in Spark 2.0+.**
+**This library does not guarantee the compatibility for Spark 2.0+. This library has been ported into Spark 2.0+. Please use the internal CSV datasource in Spark 2.0+.**
 
 # CSV Data Source for Apache Spark
 


### PR DESCRIPTION
This PR adds a warning message in documentation for incompatibility for Spark 2.0.