### PR TITLE
Treat nullValue for string as well

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -46,13 +46,9 @@ object TypeCast {
       treatEmptyValuesAsNulls: Boolean = false,
       nullValue: String = "",
       dateFormatter: SimpleDateFormat = null): Any = {
-    // if nullValue is not an empty string, don't require treatEmptyValuesAsNulls
-    // to be set to true
-    val nullValueIsNotEmpty = nullValue != ""
     if (datum == nullValue &&
-      nullable &&
-      (!castType.isInstanceOf[StringType] || treatEmptyValuesAsNulls || nullValueIsNotEmpty)
-      ){
+      nullable ||
+      (treatEmptyValuesAsNulls && datum == "")){
       null
     } else {
       castType match {

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -230,15 +230,25 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
 
     agesDf.saveAsCsvFile(copyFilePath, Map("header" -> "true", "nullValue" -> ""))
 
-    val agesCopy = new CsvParser()
+    val agesCopyOne = new CsvParser()
       .withSchema(agesSchema)
       .withUseHeader(true)
       .withTreatEmptyValuesAsNulls(true)
       .withParserLib(parserLib)
       .csvFile(sqlContext, copyFilePath)
 
-    assert(agesCopy.count == agesRows.size)
-    assert(agesCopy.collect.toSet == agesRows.toSet)
+    assert(agesCopyOne.count == agesRows.size)
+    assert(agesCopyOne.collect.toSet == agesRows.toSet)
+
+    val agesCopyTwo = new CsvParser()
+      .withSchema(agesSchema)
+      .withUseHeader(true)
+      .withNullValue("")
+      .withParserLib(parserLib)
+      .csvFile(sqlContext, copyFilePath)
+
+    assert(agesCopyTwo.count == agesRows.size)
+    assert(agesCopyTwo.collect.toSet == agesRows.toSet)
   }
 
   test("DSL test for tokens more than the schema") {

--- a/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/CsvSuite.scala
@@ -399,10 +399,10 @@ abstract class AbstractCsvSuite extends FunSuite with BeforeAndAfterAll {
            |CREATE TEMPORARY TABLE carsTable
            |(yearMade double, makeName string, modelName string, comments string, grp string)
            |USING com.databricks.spark.csv
-           |OPTIONS (path "$carsFile", header "true", parserLib "$parserLib")
+           |OPTIONS (path "$carsFile", header "true", parserLib "$parserLib", nullValue "-")
       """.stripMargin.replaceAll("\n", " "))
 
-    assert(sqlContext.sql("SELECT makeName FROM carsTable").collect().size === numCars)
+    assert(sqlContext.sql("SELECT makeName FROM carsTable").collect().length === numCars)
     assert(sqlContext.sql("SELECT avg(yearMade) FROM carsTable where grp = '' group by grp")
       .collect().head(0) === 2004.5)
   }

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -61,12 +61,16 @@ class TypeCastSuite extends FunSuite {
   }
 
   test("Nullable types are handled") {
-    assert(TypeCast.castTo("", IntegerType, nullable = true) == null)
-  }
-
-  test("String type should always return the same as the input") {
-    assert(TypeCast.castTo("", StringType, nullable = true) == "")
-    assert(TypeCast.castTo("", StringType, nullable = false) == "")
+    assert(TypeCast.castTo("-", ByteType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", ShortType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", IntegerType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", LongType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", FloatType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", DoubleType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", BooleanType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", TimestampType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", DateType, nullable = true, nullValue = "-") == null)
+    assert(TypeCast.castTo("-", StringType, nullable = true, nullValue = "-") == null)
   }
 
   test("Throws exception for empty string with non null type") {
@@ -112,7 +116,7 @@ class TypeCastSuite extends FunSuite {
     assert(TypeCast.castTo("\\N", ByteType, true, false, "\\N") == null)
     assert(TypeCast.castTo("", ShortType, true, false) == null)
     assert(TypeCast.castTo("null", StringType, true, true, "null") == null)
-    assert(TypeCast.castTo("", StringType, true, false, "") == "")
+    assert(TypeCast.castTo("", StringType, true, false, "") == null)
     assert(TypeCast.castTo("", StringType, true, true, "") == null)
   }
 }


### PR DESCRIPTION
https://github.com/databricks/spark-csv/issues/370

This PR fixes `nullValue` handling for `StringType`. It seems it'd be better to treat all the types consistently.