### PR TITLE
Fixed width support. 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,8 @@ libraryDependencies ++= Seq(
   "com.univocity" % "univocity-parsers" % "1.5.1",
   "org.slf4j" % "slf4j-api" % "1.7.5" % "provided",
   "org.scalatest" %% "scalatest" % "2.2.1" % "test",
-  "com.novocode" % "junit-interface" % "0.9" % "test"
+  "com.novocode" % "junit-interface" % "0.9" % "test",
+  "org.specs2" %% "specs2-core" % "3.7" % "test"
 )
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -391,14 +391,13 @@ case class FixedWidthRelation protected[spark] (
   codec: String = null,
   nullValue: String = "",
   dateFormat: String = null,
-  maxCharsPerCol: Int = 100000)(@transient override val sqlContext: SQLContext)
+  maxCharsPerCol: Int = 100000,
+  escape: Character = null,
+  quote: Character = null,
+  delimiter: Char = '\0',
+  inferCsvSchema: Boolean = true,
+  parserLib: String = "UNIVOCITY")(@transient override val sqlContext: SQLContext)
   extends Relation {
-
-  val escape = null
-  val quote = null
-  val delimiter = '\0'
-  val inferCsvSchema = true
-  val parserLib = "UNIVOCITY"
 
   override def getLineReader: LineReader = {
     val commentChar: Char = if (comment == null) '\0' else comment

--- a/src/test/resources/fruit__fixedwidth.txt
+++ b/src/test/resources/fruit__fixedwidth.txt
@@ -1,0 +1,7 @@
+56 apple     TRUE 0.56
+45 pear      FALSE1.34
+34 raspberry TRUE 2.43
+34 plum      TRUE 1.31
+53 cherry    TRUE 1.4 
+23 orange    FALSE2.34
+56 persimmon FALSE23.2

--- a/src/test/resources/fruit_comments_fixedwidth.txt
+++ b/src/test/resources/fruit_comments_fixedwidth.txt
@@ -1,0 +1,11 @@
+// Fruit for sale
+// 2014-10-02
+AMTNAME      AVAILCOST
+56 apple     TRUE 0.56
+45 pear      FALSE1.34
+34 raspberry TRUE 2.43
+34 plum      TRUE 1.31
+53 cherry    TRUE 1.4 
+23 orange    FALSE2.34
+56 persimmon FALSE23.2
+// No more fruit to show

--- a/src/test/resources/fruit_malformed_fixedwidth.txt
+++ b/src/test/resources/fruit_malformed_fixedwidth.txt
@@ -1,0 +1,7 @@
+23 apple     TRUE 1.44
+45 cherry    FALSE1.33
+34 raspberry TRUE BLR
+34
+ewfergerfgrefergregreg
+hi pear
+56 persimmon FALSE23.2

--- a/src/test/resources/fruit_overflow_fixedwidth.txt
+++ b/src/test/resources/fruit_overflow_fixedwidth.txt
@@ -1,0 +1,7 @@
+56 apple     TRUE 0.56
+45 pear      FALSE1.34
+34 raspberry TRUE 2.436565
+34 plum      TRUE 1.31
+53 cherry    TRUE 1.4 
+23 orange    FALSE2.3466
+56 persimmon FALSE23.2

--- a/src/test/resources/fruit_underflow_fixedwidth.txt
+++ b/src/test/resources/fruit_underflow_fixedwidth.txt
@@ -1,0 +1,7 @@
+56 apple     TRUE 0.56
+45 pear      FALSE1.34
+34 raspberry TRUE 2
+34 plum      TRUE 1.31
+53 cherry    TRUE 1
+23 orange    FALSE2.34
+56 persimmon FALSE23.2

--- a/src/test/resources/fruit_w_headers_fixedwidth.txt
+++ b/src/test/resources/fruit_w_headers_fixedwidth.txt
@@ -1,0 +1,8 @@
+AMTNAME      SALE COST
+56 apple     TRUE 0.56
+45 pear      FALSE1.34
+34 raspberry TRUE 2.43
+34 plum      TRUE 1.31
+53 cherry    TRUE 1.4 
+23 orange    FALSE2.34
+56 persimmon FALSE23.2

--- a/src/test/resources/fruit_wrong_schema_fixedwidth.txt
+++ b/src/test/resources/fruit_wrong_schema_fixedwidth.txt
@@ -1,0 +1,7 @@
+so apple     TRUE 0.56
+on pear      FALSE1.34
+hi raspberry TRUE 2.43
+yo plum      TRUE 1.31
+ni cherry    TRUE 1.4
+po orange    FALSE2.34
+no persimmon FALSE23.2

--- a/src/test/scala/com/databricks/spark/csv/FixedWidthSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/FixedWidthSuite.scala
@@ -1,0 +1,122 @@
+package com.databricks.spark.csv
+
+import org.apache.spark.{SparkContext, SparkException}
+import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.{DataFrame, Row, SQLContext}
+import org.specs2.mutable.Specification
+import org.specs2.specification.After
+
+trait FixedWidthSetup extends After {
+  protected def fruit_resource(name: String = ""): String =
+    s"src/test/resources/fruit_${name}_fixedwidth.txt"
+
+  protected val fruitWidths = Array(3, 10, 5, 4)
+  protected val fruitSize = 7
+  protected val malformedFruitSize = 5
+  protected val fruitFirstRow = Seq(56, "apple", "TRUE", 0.56)
+
+  protected val fruitSchema = StructType(Seq(
+    StructField("val", IntegerType),
+    StructField("name", StringType),
+    StructField("avail", StringType),
+    StructField("cost", DoubleType)
+  ))
+
+  val sqlContext: SQLContext = new SQLContext(new SparkContext("local[2]", "FixedwidthSuite"))
+
+  def after: Unit = sqlContext.sparkContext.stop()
+}
+
+class FixedWidthSpec extends Specification with FixedWidthSetup {
+
+  protected def sanityChecks(resultSet: DataFrame) = {
+    resultSet.show()
+    resultSet.collect().length mustEqual fruitSize
+
+    val head = resultSet.head()
+    head.length mustEqual fruitWidths.length
+    head.toSeq mustEqual fruitFirstRow
+  }
+
+  "FixedwidthParser" should {
+    "Parse a basic fixed width file, successfully" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource(), fruitWidths, fruitSchema,
+        useHeader = false)
+      sanityChecks(result)
+    }
+
+    "Parse a fw file with headers, and ignore them" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("w_headers"), fruitWidths,
+        fruitSchema, useHeader = true)
+      sanityChecks(result)
+    }
+
+    "Parse a fw file with overflowing lines, and ignore the overflow" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("overflow"), fruitWidths,
+        fruitSchema, useHeader = false)
+      sanityChecks(result)
+    }
+
+    "Parse a fw file with underflowing lines, successfully " in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("underflow"), fruitWidths,
+        fruitSchema, useHeader = false)
+      sanityChecks(result)
+    }
+
+    "Parse a basic fw file without schema and without inferring types, successfully" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource(), fruitWidths,
+        useHeader = false, inferSchema = false)
+      sanityChecks(result)
+    }
+
+    "Parse a basic fw file without schema, and infer the schema" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource(), fruitWidths,
+        useHeader = false, inferSchema = true)
+      sanityChecks(result)
+    }
+
+    "Parse a fw file with headers but without schema and without inferrence, succesfully" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("w_headers"), fruitWidths,
+        useHeader = true, inferSchema = true)
+      sanityChecks(result)
+    }
+
+    "Parse a fw file with comments, and ignore those lines" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("comments"), fruitWidths,
+        useHeader = true, inferSchema = true, comment = '/')
+      sanityChecks(result)
+    }
+
+    "Parse a malformed fw and schemaless file in PERMISSIVE mode, successfully" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("malformed"), fruitWidths,
+        useHeader = false, mode = "PERMISSIVE")
+      result.show()
+      result.collect().length mustEqual fruitSize
+    }
+
+    "Parse a malformed and schemaless fw file in DROPMALFORMED mode, " +
+      "successfully dropping bad lines" in {
+      val result = sqlContext.fixedWidthFile(fruit_resource("malformed"), fruitWidths,
+        useHeader = false, mode = "DROPMALFORMED")
+      result.show()
+     result.collect().length mustEqual malformedFruitSize
+    }
+
+    "FAIL to parse a malformed fw file with schema in FAILFAST mode" in {
+      def fail: Array[Row] = {
+        sqlContext.fixedWidthFile(fruit_resource("malformed"), fruitWidths,
+          fruitSchema, useHeader = false, mode = "FAILFAST").collect()
+      }
+      fail must throwA[SparkException]
+    }
+
+    "FAIL to parse a fw file with the wrong format" in {
+      def fail: Array[Row] = {
+        sqlContext.fixedWidthFile(fruit_resource("wrong_schema"), fruitWidths,
+          fruitSchema, useHeader = false).collect()
+      }
+      fail must throwA[SparkException]
+    }
+  }
+
+}

--- a/src/test/scala/com/databricks/spark/csv/FixedWidthSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/FixedWidthSuite.scala
@@ -1,7 +1,7 @@
 package com.databricks.spark.csv
 
 import org.apache.spark.{SparkContext, SparkException}
-import org.apache.spark.sql.types.{DoubleType, IntegerType, StringType, StructField, StructType}
+import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.specs2.mutable.Specification
 import org.specs2.specification.After
@@ -13,16 +13,18 @@ trait FixedWidthSetup extends After {
   protected val fruitWidths = Array(3, 10, 5, 4)
   protected val fruitSize = 7
   protected val malformedFruitSize = 5
-  protected val fruitFirstRow = Seq(56, "apple", "TRUE", 0.56)
+  protected val fruitFirstRow = Seq(56, "apple", true, 0.56)
 
   protected val fruitSchema = StructType(Seq(
     StructField("val", IntegerType),
     StructField("name", StringType),
-    StructField("avail", StringType),
+    StructField("avail", BooleanType),
     StructField("cost", DoubleType)
   ))
 
-  val sqlContext: SQLContext = new SQLContext(new SparkContext("local[2]", "FixedwidthSuite"))
+  val sqlContext: SQLContext = new SQLContext(
+    new SparkContext(master = "local[2]", appName = "FixedwidthSuite")
+  )
 
   def after: Unit = sqlContext.sparkContext.stop()
 }
@@ -41,7 +43,7 @@ class FixedWidthSpec extends Specification with FixedWidthSetup {
   "FixedwidthParser" should {
     "Parse a basic fixed width file, successfully" in {
       val result = sqlContext.fixedWidthFile(fruit_resource(), fruitWidths, fruitSchema,
-        useHeader = false)
+        useHeader = false, ignoreLeadingWhiteSpace = true, ignoreTrailingWhiteSpace = true)
       sanityChecks(result)
     }
 


### PR DESCRIPTION
Adds Relation, LineReader and BulkReader traits to avoid duplicated code. Largely derived from https://github.com/quartethealth/spark-csv and https://github.com/quartethealth/spark-fixedwidth.

This is in response to the following PR (created by @blrnw3) being closed without a merge:

https://github.com/databricks/spark-csv/pull/259

A fixed-width parser is a very common use case that I think several users would enjoy using. We plan to use this in our current production environment. 
