### PR TITLE
delete ";" to match style to others

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ selectedData.write
 You can manually specify the schema when reading data:
 ```scala
 import org.apache.spark.sql.SQLContext
-import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType};
+import org.apache.spark.sql.types.{StructType, StructField, StringType, IntegerType}
 
 val sqlContext = new SQLContext(sc)
 val customSchema = StructType(Array(


### PR DESCRIPTION
I think it is better to delete ";" to match another scala source styles.