### PR TITLE
Should read null properly when schema is lager than parsed tokens in PrunedScan

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
+++ b/src/main/scala/com/databricks/spark/csv/CsvRelation.scala
@@ -118,8 +118,8 @@ case class CsvRelation protected[spark] (
           index = 0
           while (index < schemaFields.length) {
             val field = schemaFields(index)
-            rowArray(index) = TypeCast.castTo(tokens(index), field.dataType, field.nullable,
-              treatEmptyValuesAsNulls, nullValue, simpleDateFormatter)
+            rowArray(index) = TypeCast.castTo(tokens(index), field.name, field.dataType,
+              field.nullable, treatEmptyValuesAsNulls, nullValue, simpleDateFormatter)
             index = index + 1
           }
           Some(Row.fromSeq(rowArray))
@@ -195,6 +195,7 @@ case class CsvRelation protected[spark] (
               val field = schemaFields(index)
               rowArray(subIndex) = TypeCast.castTo(
                 indexSafeTokens(index),
+                field.name,
                 field.dataType,
                 field.nullable,
                 treatEmptyValuesAsNulls,

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -57,7 +57,7 @@ object TypeCast {
 
     // If the given column is not nullable, we simply fall back to normal string
     // rather than returning null for backwards compatibility. Note that this case is
-    // different with Spark's internal CSV datasource.
+    // different with Spark's internal CSV datasource which throws an exception in this case.
     val isNullValueMatched = datum == nullValue && nullable
 
     // If `treatEmptyValuesAsNulls` is enabled, treat empty strings as nulls.
@@ -67,7 +67,7 @@ object TypeCast {
     // In this case, they are treated as nulls.
     val isNullDatum = datum == null
 
-    if (isNullValueMatched || shouldTreatEmptyValuesAsNulls || isNullDatum){
+    if (isNullValueMatched || shouldTreatEmptyValuesAsNulls || isNullDatum) {
       if (!nullable) {
         throw new RuntimeException(s"null value found but field $name is not nullable.")
       }

--- a/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
+++ b/src/main/scala/com/databricks/spark/csv/util/TypeCast.scala
@@ -34,21 +34,43 @@ object TypeCast {
    * Currently we do not support complex types (ArrayType, MapType, StructType).
    *
    * For string types, this is simply the datum. For other types.
-   * For other nullable types, this is null if the string datum is empty.
+   * For other nullable types, returns null if it is null or equals to the value specified
+   * in `nullValue` option. If `treatEmptyValuesAsNulls` is set, it also returns null for
+   * empty strings.
    *
    * @param datum string value
-   * @param castType SparkSQL type
+   * @param name field name in schema.
+   * @param castType data type to cast `datum` into.
+   * @param nullable nullability for the field.
+   * @param treatEmptyValuesAsNulls a flag to indicate if empty strings should be treated as null.
+   * @param nullValue the string value that represents null.
+   * @param dateFormatter date formatter that uses to parse dates and timestamps.
    */
   private[csv] def castTo(
       datum: String,
+      name: String,
       castType: DataType,
       nullable: Boolean = true,
       treatEmptyValuesAsNulls: Boolean = false,
       nullValue: String = "",
       dateFormatter: SimpleDateFormat = null): Any = {
-    if (datum == nullValue &&
-      nullable ||
-      (treatEmptyValuesAsNulls && datum == "")){
+
+    // If the given column is not nullable, we simply fall back to normal string
+    // rather than returning null for backwards compatibility. Note that this case is
+    // different with Spark's internal CSV datasource.
+    val isNullValueMatched = datum == nullValue && nullable
+
+    // If `treatEmptyValuesAsNulls` is enabled, treat empty strings as nulls.
+    val shouldTreatEmptyValuesAsNulls = treatEmptyValuesAsNulls && datum == ""
+
+    // `datum` can be null when some tokens were inserted when permissive modes via `PrunedScan`.
+    // In this case, they are treated as nulls.
+    val isNullDatum = datum == null
+
+    if (isNullValueMatched || shouldTreatEmptyValuesAsNulls || isNullDatum){
+      if (!nullable) {
+        throw new RuntimeException(s"null value found but field $name is not nullable.")
+      }
       null
     } else {
       castType match {

--- a/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
+++ b/src/test/scala/com/databricks/spark/csv/util/TypeCastSuite.scala
@@ -74,17 +74,17 @@ class TypeCastSuite extends FunSuite {
   }
 
   test("Throws exception for empty string with non null type") {
-    val exception1 = intercept[NumberFormatException]{
+    val exception1 = intercept[NumberFormatException] {
       TypeCast.castTo("", "_c", IntegerType, nullable = false)
     }
     assert(exception1.getMessage.contains("For input string: \"\""))
 
-    val exception2 = intercept[RuntimeException]{
+    val exception2 = intercept[RuntimeException] {
       TypeCast.castTo("", "_c", StringType, nullable = false, treatEmptyValuesAsNulls = true)
     }
     assert(exception2.getMessage.contains("null value found but field _c is not nullable"))
 
-    val exception3 = intercept[RuntimeException]{
+    val exception3 = intercept[RuntimeException] {
       TypeCast.castTo(null, "_c", StringType, nullable = false)
     }
     assert(exception3.getMessage.contains("null value found but field _c is not nullable"))


### PR DESCRIPTION
Currently running the codes below:

```scala
val schema = StructType(
  StructField("bool", BooleanType, true) ::
  StructField("nullcol", IntegerType, true) ::
  StructField("nullcol1", IntegerType, true) :: Nil)

new CsvParser()
  .withSchema(schema)
  .withUseHeader(true)
  .withParserLib(parserLib)
  .withParseMode(ParseModes.PERMISSIVE_MODE)
  .csvFile(sqlContext, boolFile)
  .select("bool", "nullcol")
  .collect()
```

with the data below:

```csv
bool
"True"
"False"

"true"
```

throws an exception as below:

```
java.lang.NumberFormatException: null
	at java.lang.Integer.parseInt(Integer.java:542)
	at java.lang.Integer.parseInt(Integer.java:615)
	at scala.collection.immutable.StringLike$class.toInt(StringLike.scala:272)
	at scala.collection.immutable.StringOps.toInt(StringOps.scala:30)
	at com.databricks.spark.csv.util.TypeCast$.castTo(TypeCast.scala:57)
	at com.databricks.spark.csv.CsvRelation$$anonfun$buildScan$6.apply(CsvRelation.scala:196)
	at com.databricks.spark.csv.CsvRelation$$anonfun$buildScan$6.apply(CsvRelation.scala:174)
```

This is related with https://github.com/apache/spark/pull/15767. Please refer the description there.

