### PR TITLE
Fix javadoc for saveAsCsvFile

### DIFF
--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -93,7 +93,7 @@ package object csv {
   implicit class CsvSchemaRDD(dataFrame: DataFrame) {
 
     /**
-     * Saves DataFrame as csv files. By default uses ',' as delimiter, and includes header line.
+     * Saves DataFrame as csv files. By default uses ',' as delimiter, and doesn't include header line.
      * If compressionCodec is not null the resulting output will be compressed.
      * Note that a codec entry in the parameters map will be ignored.
      */

--- a/src/main/scala/com/databricks/spark/csv/package.scala
+++ b/src/main/scala/com/databricks/spark/csv/package.scala
@@ -93,7 +93,8 @@ package object csv {
   implicit class CsvSchemaRDD(dataFrame: DataFrame) {
 
     /**
-     * Saves DataFrame as csv files. By default uses ',' as delimiter, and doesn't include header line.
+     * Saves DataFrame as csv files. By default uses ',' as delimiter,
+     * and doesn't include header line.
      * If compressionCodec is not null the resulting output will be compressed.
      * Note that a codec entry in the parameters map will be ignored.
      */


### PR DESCRIPTION
On line 150, the code actually defaults to `false` for the `header` option.
This agrees with the documentation in the project README.